### PR TITLE
Feat: (#3) 성공, 에러 응답의 공통 형식을 지정한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Configuration ###
+src/main/resources/application-*.yml

--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,34 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	// WEB
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	annotationProcessor 'org.projectlombok:lombok'
+
+	// Testing
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Development tools (for local development only)
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
+	// DB, JPA
+	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// Spring Security & OAuth2
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// Lombok (code simplification)
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// Validation (for request/response validation)
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// WebSocket (for real-time communication)
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/src/main/java/spring/backend/core/exception/DomainException.java
+++ b/src/main/java/spring/backend/core/exception/DomainException.java
@@ -1,0 +1,28 @@
+package spring.backend.core.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+import spring.backend.core.exception.error.BaseErrorCode;
+
+@Getter
+public class DomainException extends RuntimeException {
+
+  private HttpStatus httpStatus;
+
+  private String code;
+
+  public DomainException(String message) {
+    super(message);
+  }
+
+  public DomainException(HttpStatus httpStatus, String message) {
+    super(message);
+    this.httpStatus = httpStatus;
+  }
+
+  public DomainException(HttpStatus httpStatus, BaseErrorCode<?> errorCode) {
+    super(errorCode.getMessage());
+    this.httpStatus = httpStatus;
+    this.code = errorCode.name();
+  }
+}

--- a/src/main/java/spring/backend/core/exception/GlobalExceptionHandler.java
+++ b/src/main/java/spring/backend/core/exception/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package spring.backend.core.exception;
+
+import java.util.Optional;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import spring.backend.core.presentation.ErrorResponse;
+
+@RestControllerAdvice
+@Log4j2
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+  @ExceptionHandler(Exception.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  public final ErrorResponse handleAllExceptions(Exception ex, WebRequest request) {
+    logger.error("ERROR ::: [AllException] ", ex);
+    return ErrorResponse.of(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(DomainException.class)
+  public final ErrorResponse handleDomainException(DomainException ex) {
+    HttpStatus httpStatus = Optional.ofNullable(ex.getHttpStatus()).orElse(HttpStatus.INTERNAL_SERVER_ERROR);
+    log.error("ERROR ::: [DomainException] ", ex);
+    return ErrorResponse.of(ex.getMessage(), httpStatus);
+  }
+}

--- a/src/main/java/spring/backend/core/exception/error/BaseErrorCode.java
+++ b/src/main/java/spring/backend/core/exception/error/BaseErrorCode.java
@@ -1,0 +1,14 @@
+package spring.backend.core.exception.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode<T extends Exception> {
+
+  String name();
+
+  String getMessage();
+
+  HttpStatus getHttpStatus();
+
+  T toException();
+}

--- a/src/main/java/spring/backend/core/exception/error/GlobalErrorCode.java
+++ b/src/main/java/spring/backend/core/exception/error/GlobalErrorCode.java
@@ -1,0 +1,22 @@
+package spring.backend.core.exception.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements BaseErrorCode<RuntimeException> {
+
+  ALREADY_PROCESS_STARTED(HttpStatus.BAD_REQUEST, "이미 처리중인 요청입니다."),
+  INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 내부 오류입니다.");
+
+  private final HttpStatus httpStatus;
+
+  private final String message;
+
+  @Override
+  public RuntimeException toException() {
+    return new RuntimeException(message);
+  }
+}

--- a/src/main/java/spring/backend/core/presentation/ApiResponse.java
+++ b/src/main/java/spring/backend/core/presentation/ApiResponse.java
@@ -1,0 +1,34 @@
+package spring.backend.core.presentation;
+
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApiResponse<T> {
+
+  private boolean success;
+
+  private int status;
+
+  private T body;
+
+  @Builder.Default
+  private LocalDateTime timestamp = LocalDateTime.now();
+
+  public static ApiResponse of(boolean success, int status, Object body) {
+    return ApiResponse.builder()
+        .success(success)
+        .status(status)
+        .body(body)
+        .build();
+  }
+}

--- a/src/main/java/spring/backend/core/presentation/ErrorResponse.java
+++ b/src/main/java/spring/backend/core/presentation/ErrorResponse.java
@@ -1,0 +1,18 @@
+package spring.backend.core.presentation;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class ErrorResponse {
+
+  private final String message;
+
+  private final HttpStatus httpStatus;
+
+  public static ErrorResponse of(String message, HttpStatus httpStatus) {
+    return new ErrorResponse(message, httpStatus);
+  }
+}

--- a/src/main/java/spring/backend/core/presentation/ResponseWrapper.java
+++ b/src/main/java/spring/backend/core/presentation/ResponseWrapper.java
@@ -1,0 +1,39 @@
+package spring.backend.core.presentation;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(basePackages = "spring.backend")
+@Log4j2
+public class ResponseWrapper implements ResponseBodyAdvice<Object> {
+
+  @Override
+  public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+    log.info("execute AOP - supports");
+    log.info("execute AOP - returnType :: {}", returnType);
+    log.info("execute AOP - converterType :: {}", converterType);
+    return true;
+  }
+
+  @Override
+  public Object beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType, Class<? extends HttpMessageConverter<?>> selectedConverterType,
+      ServerHttpRequest request, ServerHttpResponse response) {
+    log.info("execute AOP - beforeBodyWrite");
+    HttpServletResponse servletResponse = ((ServletServerHttpResponse) response).getServletResponse();
+    int status = servletResponse.getStatus();
+    if (body instanceof ErrorResponse) {
+      HttpStatus errorStatus = ((ErrorResponse) body).getHttpStatus();
+      return ApiResponse.of(false, errorStatus.value(), body);
+    }
+    return ApiResponse.of(true, status, body);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=backend

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: backend


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
### 성공 응답
![스크린샷 2024-10-09 오전 5 45 53](https://github.com/user-attachments/assets/0db8452e-f9f4-4e1b-a6b5-ff39a99d730d)


### 공통 에러 응답
![스크린샷 2024-10-09 오전 5 46 03](https://github.com/user-attachments/assets/8202ce15-ed09-445e-8754-8941660b482f)


### 도메인 에러 응답
![스크린샷 2024-10-09 오전 5 58 58](https://github.com/user-attachments/assets/4554bb6f-c8c2-45d4-8f7f-339b3a4f7863)

- 공통 응답 (성공, 실패(에러)) 형식을 지정하여 생성하였습니다.
- 전역에서 발생할 수 있는 GlobalErrorCode와 도메인에서 발생할 수 있는 DomainException을 생성하였습니다.
  - DomainException은 도메인 로직에서 BaseErrorCode<DomainException>를 implements하여 사용합니다.
- 원래는 컨트롤러에서 응답 보낼 시 `ResponseEntity<Object>`와 같이 보내는데 현재 ResponseWrapper 를 통해 `Object(DTO)` 만 반환해도 ApiResponse로 감싸서 반환합니다.

---

## ✏️ 관련 이슈
- Resolves : #3 

---

## 🎸 기타 사항 or 추가 코멘트

