### PR TITLE
Feat: (#7) Swagger를 적용하여 API 문서를 생성한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 
 	// WebSocket (for real-time communication)
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+	// Swagger-UI
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/spring/backend/core/configuration/swagger/ApiErrorCode.java
+++ b/src/main/java/spring/backend/core/configuration/swagger/ApiErrorCode.java
@@ -1,0 +1,14 @@
+package spring.backend.core.configuration.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import spring.backend.core.exception.error.BaseErrorCode;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCode {
+
+  Class<? extends BaseErrorCode>[] value();
+}

--- a/src/main/java/spring/backend/core/configuration/swagger/ExampleHolder.java
+++ b/src/main/java/spring/backend/core/configuration/swagger/ExampleHolder.java
@@ -1,0 +1,16 @@
+package spring.backend.core.configuration.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+  private Example holder;
+
+  private int code;
+
+  private String name;
+}

--- a/src/main/java/spring/backend/core/configuration/swagger/SwaggerConfiguration.java
+++ b/src/main/java/spring/backend/core/configuration/swagger/SwaggerConfiguration.java
@@ -1,0 +1,102 @@
+package spring.backend.core.configuration.swagger;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+import spring.backend.core.exception.error.BaseErrorCode;
+import spring.backend.core.presentation.ErrorResponse;
+
+@Configuration
+@OpenAPIDefinition(info = @Info(title = "C-nergy API", description = "C-nergy : API 명세서", version = "v1.0.0"))
+public class SwaggerConfiguration {
+
+  @Bean
+  public OpenAPI openAPI(){
+    SecurityScheme securityScheme = new SecurityScheme()
+        .type(Type.HTTP).scheme("bearer").bearerFormat("JWT")
+        .in(In.HEADER).name("Authorization");
+    SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+    return new OpenAPI()
+        .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+        .security(Arrays.asList(securityRequirement));
+  }
+
+  @Bean
+  public OperationCustomizer operationCustomizer() {
+    return (Operation operation, HandlerMethod handlerMethod) -> {
+      ApiErrorCode apiErrorCode = handlerMethod.getMethodAnnotation(ApiErrorCode.class);
+      if (apiErrorCode != null) {
+        generateErrorCodeResponseExample(operation, apiErrorCode.value());
+      }
+      return operation;
+    };
+  }
+
+  private void generateErrorCodeResponseExample(Operation operation, Class<? extends BaseErrorCode>[] types) {
+    ApiResponses responses = operation.getResponses();
+    List<ExampleHolder> exampleHolders = new ArrayList<>();
+
+    for (Class<? extends BaseErrorCode> type : types) {
+      BaseErrorCode[] errorCodes = type.getEnumConstants();
+      Arrays.stream(errorCodes).map(
+          baseErrorCode -> ExampleHolder.builder()
+              .holder(getSwaggerExample(baseErrorCode))
+              .code(baseErrorCode.getHttpStatus().value())
+              .name(baseErrorCode.name())
+              .build()
+      ).forEach(exampleHolders::add);
+    }
+
+    Map<Integer, List<ExampleHolder>> statusWithExampleHolders = new HashMap<>(
+        exampleHolders.stream()
+            .collect(Collectors.groupingBy(ExampleHolder::getCode)));
+
+    addExamplesToResponses(responses, statusWithExampleHolders);
+  }
+
+  private Example getSwaggerExample(BaseErrorCode baseErrorCode) {
+    ErrorResponse errorResponse = ErrorResponse.createSwaggerErrorResponse()
+        .baseErrorCode(baseErrorCode)
+        .build();
+    Example example = new Example();
+    example.setValue(errorResponse);
+    return example;
+  }
+
+  private void addExamplesToResponses(ApiResponses responses, Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+    statusWithExampleHolders.forEach(
+        (status, value) -> {
+          Content content = new Content();
+          MediaType mediaType = new MediaType();
+          ApiResponse apiResponse = new ApiResponse();
+          value.forEach(exampleHolder -> mediaType.addExamples(exampleHolder.getName(),
+              exampleHolder.getHolder()));
+          content.addMediaType("application/json", mediaType);
+          apiResponse.setContent(content);
+          responses.addApiResponse(status.toString(), apiResponse);
+        }
+    );
+  }
+}

--- a/src/main/java/spring/backend/core/presentation/ErrorResponse.java
+++ b/src/main/java/spring/backend/core/presentation/ErrorResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import spring.backend.core.exception.DomainException;
+import spring.backend.core.exception.error.BaseErrorCode;
 
 @Getter
 public class ErrorResponse extends BaseResponse {
@@ -28,5 +29,13 @@ public class ErrorResponse extends BaseResponse {
     this.statusCode = statusCode;
     this.code = exception.getCode();
     this.message = exception.getMessage();
+  }
+
+  @Builder(builderClassName = "CreateSwaggerErrorResponse", builderMethodName = "createSwaggerErrorResponse")
+  public ErrorResponse(BaseErrorCode baseErrorCode) {
+    super(false, LocalDateTime.now());
+    this.statusCode = baseErrorCode.getHttpStatus().value();
+    this.code = baseErrorCode.name();
+    this.message = baseErrorCode.getMessage();
   }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

### 1. [fix: 에러 응답 구조를 변경하고 에러 응답 반환 시 발생하는 예외를 처리](https://github.com/KUSITMS-30th-TEAM-C/backend/commit/14c303ae568467e5c50206509edbe0b67e2c0f91)

이전 #3 이슈에서 구현했던 응답 구조에서 `status`와 `httpStatus`가 유사하게 보이는 문제가 있었습니다. 또한, 스웨거에서 에러 응답 예시 값이 제가 원하는 형식과 달라 이를 수정하였습니다.

**AS-IS**: `"404 NOT_FOUND"`  
**TO-BE**: `"NOT_FOUND"`

이를 해결하기 위해 에러 응답 필드 구조를 변경했습니다.  
변경하면서 `ResponseWrapper`에서 `status` 값을 넣을 때, 기존에는 `HttpStatus` 객체를 사용했으나, 이제는 `String`의 `code`를 사용합니다. 또한, `code`를 `HttpStatus`로 변환하여 사용하고, 만약 변환에 실패하면 `INTERNAL_SERVER_ERROR`를 반환하도록 처리하였습니다.

### 2. [feat: Swagger 설정을 추가](https://github.com/KUSITMS-30th-TEAM-C/backend/commit/636cff223544b5bd6f96974a43a1ca24ae5efbae)

- `ApiErrorCode` 어노테이션을 새로 만들었습니다.  
  이를 통해 추후 Controller에 해당 어노테이션을 사용하면 Service에서 발생하는 Exception을 Swagger의 응답 예시에서 자동으로 보여줄 수 있습니다.

- Swagger Configuration 설정을 추가하였습니다.  
  이를 통해 Swagger 문서에서 인증 정보 설정과 더불어 에러 응답에 대한 예시도 포함되도록 구성하였습니다.

![스크린샷 2024-10-10 오전 10 22 41](https://github.com/user-attachments/assets/b4566b8f-7827-42db-8747-42ded510331f)
![스크린샷 2024-10-10 오전 10 23 01](https://github.com/user-attachments/assets/1bff303a-d04a-4735-bfb1-a13d33071b72)


---

## ✏️ 관련 이슈
- Fixes : #3 
- Resolves : #7 

---

## 🎸 기타 사항 or 추가 코멘트
### 스웨거 설정하면서 발생했던 문제

이번에 ResponseBodyAdvice를 사용하면서 발생했던 문제라고 보여집니다.

- 성공 응답 예시에서 dto 구조만 반환

#### 기대값
```
{
  "success": true,
  "status": 200,
  "body": {
    "id": 123,
    "name": "123"
  },
  "timestamp": "2024-10-10T10:46:53.760909"
}
```

#### 결과값
```
"id": 123,
"name": "123"
```

에러 응답의 경우 어노테이션인 ApiErrorCode를 통해서 얻어온 값으로 ErrorResponse를 만들어서 괜찮은데
성공 응답의 경우 어노테이션을 통해 만드는게 아니기 때문에 어떻게 하지 하다가
[참고 블로그](https://gengminy.tistory.com/61) 이거 보고 해결했습니다~