### PR TITLE
Feat: (#13) 소셜 로그인을 구현한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,10 +39,6 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-	// Spring Security & OAuth2
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-
 	// Lombok (code simplification)
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/spring/backend/BackendApplication.java
+++ b/src/main/java/spring/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package spring.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/spring/backend/auth/application/AuthorizeOAuthService.java
+++ b/src/main/java/spring/backend/auth/application/AuthorizeOAuthService.java
@@ -1,0 +1,29 @@
+package spring.backend.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import spring.backend.auth.exception.AuthenticationErrorCode;
+import spring.backend.auth.infrastructure.OAuthRestClient;
+import spring.backend.auth.infrastructure.OAuthRestClientFactory;
+import spring.backend.member.domain.value.Provider;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class AuthorizeOAuthService {
+
+    private final OAuthRestClientFactory oAuthRestClientFactory;
+
+    public URI getAuthorizeUrl(String providerName) {
+        if (providerName == null || providerName.isEmpty()) {
+            log.error("[AuthorizeOAuthService] Invalid provider name");
+            throw AuthenticationErrorCode.NOT_EXIST_PROVIDER.toException();
+        }
+        Provider provider = Provider.valueOf(providerName.toUpperCase());
+        OAuthRestClient oAuthRestClient = oAuthRestClientFactory.getOAuthRestClient(provider);
+        return oAuthRestClient.getAuthUrl();
+    }
+}

--- a/src/main/java/spring/backend/auth/application/HandleOAuthLoginService.java
+++ b/src/main/java/spring/backend/auth/application/HandleOAuthLoginService.java
@@ -1,0 +1,57 @@
+package spring.backend.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import spring.backend.auth.dto.response.LoginResponse;
+import spring.backend.auth.dto.response.OAuthAccessTokenResponse;
+import spring.backend.auth.dto.response.OAuthResourceResponse;
+import spring.backend.auth.exception.AuthenticationErrorCode;
+import spring.backend.auth.infrastructure.OAuthRestClient;
+import spring.backend.auth.infrastructure.OAuthRestClientFactory;
+import spring.backend.member.application.CreateMemberWithOAuthService;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.value.Provider;
+import spring.backend.member.dto.request.CreateMemberWithOAuthRequest;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class HandleOAuthLoginService {
+
+    private final OAuthRestClientFactory oAuthRestClientFactory;
+
+    private final CreateMemberWithOAuthService createMemberWithOAuthService;
+
+    public LoginResponse handleOAuthLogin(String providerName, String code, String state) {
+        if (providerName == null || providerName.isEmpty()) {
+            throw AuthenticationErrorCode.NOT_EXIST_PROVIDER.toException();
+        }
+        Provider provider = Provider.valueOf(providerName.toUpperCase());
+        OAuthRestClient oAuthRestClient = oAuthRestClientFactory.getOAuthRestClient(provider);
+
+        OAuthAccessTokenResponse oAuthAccessTokenResponse = oAuthRestClient.getAccessToken(code, state);
+        if (oAuthAccessTokenResponse == null) {
+            log.error("[HandleOAuthLoginService] OAuth access token could not be retrieved.");
+            throw AuthenticationErrorCode.ACCESS_TOKEN_NOT_ISSUED.toException();
+        }
+        OAuthResourceResponse oAuthResourceResponse = oAuthRestClient.getResource(oAuthAccessTokenResponse.getAccessToken());
+        if (oAuthResourceResponse == null) {
+            log.error("[HandleOAuthLoginService] OAuth resource could not be retrieved.");
+            throw AuthenticationErrorCode.RESOURCE_SERVER_UNAVAILABLE.toException();
+        }
+
+        CreateMemberWithOAuthRequest createMemberWithOAuthRequest = CreateMemberWithOAuthRequest.builder()
+                .provider(provider)
+                .email(oAuthResourceResponse.getEmail())
+                .nickname(oAuthResourceResponse.getName())
+                .build();
+
+        Member member = createMemberWithOAuthService.createMemberWithOAuth(createMemberWithOAuthRequest);
+
+        /**
+         * todo: 사용자 정보를 가지고 AccessToken, RefreshToken을 생성한다.
+         */
+        return null;
+    }
+}

--- a/src/main/java/spring/backend/auth/dto/response/LoginResponse.java
+++ b/src/main/java/spring/backend/auth/dto/response/LoginResponse.java
@@ -1,0 +1,4 @@
+package spring.backend.auth.dto.response;
+
+public record LoginResponse(String accessToken, String refreshToken) {
+}

--- a/src/main/java/spring/backend/auth/dto/response/OAuthAccessTokenResponse.java
+++ b/src/main/java/spring/backend/auth/dto/response/OAuthAccessTokenResponse.java
@@ -1,0 +1,20 @@
+package spring.backend.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class OAuthAccessTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("expires_in")
+    private long expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+}

--- a/src/main/java/spring/backend/auth/dto/response/OAuthResourceResponse.java
+++ b/src/main/java/spring/backend/auth/dto/response/OAuthResourceResponse.java
@@ -1,0 +1,19 @@
+package spring.backend.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OAuthResourceResponse {
+
+    private String id;
+
+    private String email;
+
+    @JsonProperty("verified_email")
+    private boolean verifiedEmail;
+
+    private String name;
+}

--- a/src/main/java/spring/backend/auth/exception/AuthenticationErrorCode.java
+++ b/src/main/java/spring/backend/auth/exception/AuthenticationErrorCode.java
@@ -1,0 +1,32 @@
+package spring.backend.auth.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import spring.backend.core.exception.AuthenticationException;
+import spring.backend.core.exception.error.BaseErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthenticationErrorCode implements BaseErrorCode<AuthenticationException> {
+
+    NOT_EXIST_HEADER(HttpStatus.UNAUTHORIZED, "Authorization Header가 존재하지 않습니다."),
+    NOT_EXIST_TOKEN(HttpStatus.UNAUTHORIZED, "Authorization Header에 Token이 존재하지 않습니다."),
+    NOT_MATCH_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "토큰의 형식이 맞지 않습니다."),
+    NOT_DEFINE_TOKEN(HttpStatus.UNAUTHORIZED, "정의되지 않은 토큰입니다."),
+    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "유효한 OAuth 써드파티 제공자가 아닙니다."),
+    NOT_EXIST_PROVIDER(HttpStatus.BAD_REQUEST, "OAuth 써드파티 제공자가 존재하지 않습니다."),
+    NOT_EXIST_AUTH_CODE(HttpStatus.BAD_GATEWAY, "OAuth 써드파티 제공자에서 제공받은 인증 코드가 존재하지 않습니다."),
+    ACCESS_TOKEN_NOT_ISSUED(HttpStatus.BAD_GATEWAY, "OAuth 써드파티 제공자에서 액세스 토큰이 발급되지 않았습니다."),
+    NOT_EXIST_RESOURCE_RESPONSE(HttpStatus.BAD_GATEWAY, "OAuth 써드파티 리소스 서버에서 자원이 존재하지 않습니다."),
+    RESOURCE_SERVER_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "OAuth Resource Server에 접근할 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public AuthenticationException toException() {
+        return new AuthenticationException(message);
+    }
+}

--- a/src/main/java/spring/backend/auth/infrastructure/OAuthRestClient.java
+++ b/src/main/java/spring/backend/auth/infrastructure/OAuthRestClient.java
@@ -1,0 +1,15 @@
+package spring.backend.auth.infrastructure;
+
+import spring.backend.auth.dto.response.OAuthAccessTokenResponse;
+import spring.backend.auth.dto.response.OAuthResourceResponse;
+
+import java.net.URI;
+
+public interface OAuthRestClient {
+
+    URI getAuthUrl();
+
+    OAuthAccessTokenResponse getAccessToken(String authCode, String state);
+
+    OAuthResourceResponse getResource(String oauthToken);
+}

--- a/src/main/java/spring/backend/auth/infrastructure/OAuthRestClientFactory.java
+++ b/src/main/java/spring/backend/auth/infrastructure/OAuthRestClientFactory.java
@@ -1,0 +1,35 @@
+package spring.backend.auth.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import spring.backend.auth.exception.AuthenticationErrorCode;
+import spring.backend.auth.infrastructure.google.GoogleOAuthRestClient;
+import spring.backend.auth.infrastructure.kakao.KakaoOAuthRestClient;
+import spring.backend.auth.infrastructure.naver.NaverOAuthRestClient;
+import spring.backend.member.domain.value.Provider;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthRestClientFactory {
+
+    private final GoogleOAuthRestClient googleOAuthRestClient;
+
+    private final NaverOAuthRestClient naverOAuthRestClient;
+
+    private final KakaoOAuthRestClient kakaoOAuthRestClient;
+
+    public OAuthRestClient getOAuthRestClient(Provider provider) {
+        switch (provider) {
+            case GOOGLE -> {
+                return googleOAuthRestClient;
+            }
+            case NAVER -> {
+                return naverOAuthRestClient;
+            }
+            case KAKAO -> {
+                return kakaoOAuthRestClient;
+            }
+            default -> throw AuthenticationErrorCode.INVALID_PROVIDER.toException();
+        }
+    }
+}

--- a/src/main/java/spring/backend/auth/infrastructure/google/GoogleOAuthRestClient.java
+++ b/src/main/java/spring/backend/auth/infrastructure/google/GoogleOAuthRestClient.java
@@ -1,0 +1,89 @@
+package spring.backend.auth.infrastructure.google;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import spring.backend.auth.dto.response.OAuthAccessTokenResponse;
+import spring.backend.auth.dto.response.OAuthResourceResponse;
+import spring.backend.auth.exception.AuthenticationErrorCode;
+import spring.backend.auth.infrastructure.OAuthRestClient;
+import spring.backend.core.configuration.property.GoogleOAuthProperty;
+
+import java.net.URI;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class GoogleOAuthRestClient implements OAuthRestClient {
+
+    private static final String GRANT_TYPE = "authorization_code";
+
+    private final GoogleOAuthProperty googleOAuthProperty;
+
+    @Override
+    public URI getAuthUrl() {
+        return UriComponentsBuilder.fromUriString(googleOAuthProperty.getAuthUri())
+                .queryParam("client_id", googleOAuthProperty.getClientId())
+                .queryParam("redirect_uri", googleOAuthProperty.getRedirectUri())
+                .queryParam("response_type", "code")
+                .queryParam("scope", String.join(" ", googleOAuthProperty.getScope()))
+                .build()
+                .toUri();
+    }
+
+    @Override
+    public OAuthAccessTokenResponse getAccessToken(String authCode, String state) {
+        if (authCode == null || authCode.isEmpty()) {
+            log.error("[GoogleOAuthRestClient] authCode is null");
+            throw AuthenticationErrorCode.NOT_EXIST_AUTH_CODE.toException();
+        }
+        try {
+            return RestClient.create()
+                    .post()
+                    .uri(googleOAuthProperty.getTokenUri())
+                    .headers(header -> header.setContentType(MediaType.APPLICATION_FORM_URLENCODED))
+                    .body(createAccessTokenRequestBody(authCode))
+                    .retrieve()
+                    .body(OAuthAccessTokenResponse.class);
+        } catch (Exception e) {
+            log.error("[GoogleOAuthRestClient] error", e);
+            throw AuthenticationErrorCode.ACCESS_TOKEN_NOT_ISSUED.toException();
+        }
+    }
+
+    @Override
+    public OAuthResourceResponse getResource(String oauthToken) {
+        if (oauthToken == null || oauthToken.isEmpty()) {
+            log.error("[GoogleOAuthRestClient] oauthToken is null");
+            throw AuthenticationErrorCode.NOT_EXIST_AUTH_CODE.toException();
+        }
+        try {
+            return RestClient.create()
+                    .get()
+                    .uri(googleOAuthProperty.getResourceUri())
+                    .headers(header -> {
+                        header.setBearerAuth(oauthToken);
+                        header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                    })
+                    .retrieve()
+                    .body(OAuthResourceResponse.class);
+        } catch (Exception e) {
+            throw AuthenticationErrorCode.RESOURCE_SERVER_UNAVAILABLE.toException();
+        }
+    }
+
+    private MultiValueMap<String, String> createAccessTokenRequestBody(String authCode) {
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add("client_id", googleOAuthProperty.getClientId());
+        parameters.add("client_secret", googleOAuthProperty.getClientSecret());
+        parameters.add("code", authCode);
+        parameters.add("grant_type", GRANT_TYPE);
+        parameters.add("redirect_uri", googleOAuthProperty.getRedirectUri());
+        return parameters;
+    }
+}

--- a/src/main/java/spring/backend/auth/infrastructure/kakao/KakaoOAuthRestClient.java
+++ b/src/main/java/spring/backend/auth/infrastructure/kakao/KakaoOAuthRestClient.java
@@ -1,0 +1,112 @@
+package spring.backend.auth.infrastructure.kakao;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import spring.backend.auth.dto.response.OAuthAccessTokenResponse;
+import spring.backend.auth.dto.response.OAuthResourceResponse;
+import spring.backend.auth.exception.AuthenticationErrorCode;
+import spring.backend.auth.infrastructure.OAuthRestClient;
+import spring.backend.auth.infrastructure.kakao.dto.KakaoResourceResponse;
+import spring.backend.core.configuration.property.KakaoOAuthProperty;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class KakaoOAuthRestClient implements OAuthRestClient {
+
+    private static final String GRANT_TYPE = "authorization_code";
+
+    private final KakaoOAuthProperty kakaoOAuthProperty;
+
+    @Override
+    public URI getAuthUrl() {
+        return UriComponentsBuilder.fromUriString(kakaoOAuthProperty.getAuthUri())
+                .queryParam("client_id", kakaoOAuthProperty.getClientId())
+                .queryParam("redirect_uri", kakaoOAuthProperty.getRedirectUri())
+                .queryParam("response_type", "code")
+                .queryParam("scope", String.join(" ", kakaoOAuthProperty.getScope()))
+                .build()
+                .toUri();
+    }
+
+    @Override
+    public OAuthAccessTokenResponse getAccessToken(String authCode, String state) {
+        if (authCode == null || authCode.isEmpty()) {
+            log.error("[KakaoOAuthRestClient] authCode is null");
+            throw AuthenticationErrorCode.NOT_EXIST_AUTH_CODE.toException();
+        }
+        try {
+            return RestClient.create()
+                    .post()
+                    .uri(kakaoOAuthProperty.getTokenUri())
+                    .headers(header -> {
+                        header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                        header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+                    })
+                    .body(createAccessTokenRequestBody(authCode))
+                    .retrieve()
+                    .body(OAuthAccessTokenResponse.class);
+        } catch (Exception e) {
+            log.error("[GoogleOAuthRestClient] error", e);
+            throw AuthenticationErrorCode.ACCESS_TOKEN_NOT_ISSUED.toException();
+        }
+    }
+
+    @Override
+    public OAuthResourceResponse getResource(String oauthToken) {
+        if (oauthToken == null || oauthToken.isEmpty()) {
+            log.error("[KakaoOAuthRestClient] oauthToken is null");
+            throw AuthenticationErrorCode.NOT_EXIST_AUTH_CODE.toException();
+        }
+        try {
+            KakaoResourceResponse kakaoResourceResponse = RestClient.create()
+                    .get()
+                    .uri(kakaoOAuthProperty.getResourceUri())
+                    .headers(header -> {
+                        header.setBearerAuth(oauthToken);
+                        header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                        header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+                    })
+                    .retrieve()
+                    .body(KakaoResourceResponse.class);
+            Long id = Optional.ofNullable(kakaoResourceResponse)
+                    .map(KakaoResourceResponse::getId)
+                    .orElseThrow(AuthenticationErrorCode.NOT_EXIST_RESOURCE_RESPONSE::toException);
+            KakaoResourceResponse.Response kakaoAccount = Optional.ofNullable(kakaoResourceResponse.getKakaoAccount())
+                    .orElseThrow(AuthenticationErrorCode.NOT_EXIST_RESOURCE_RESPONSE::toException);
+            String email = Optional.ofNullable(kakaoAccount.getEmail())
+                    .orElseThrow(AuthenticationErrorCode.NOT_EXIST_RESOURCE_RESPONSE::toException);
+            String nickname = Optional.ofNullable(kakaoAccount.getProfile())
+                    .map(KakaoResourceResponse.Response.Profile::getNickname)
+                    .orElseThrow(AuthenticationErrorCode.NOT_EXIST_RESOURCE_RESPONSE::toException);
+            return OAuthResourceResponse.builder()
+                    .id(String.valueOf(id))
+                    .name(nickname)
+                    .email(email)
+                    .build();
+        } catch (Exception e) {
+            throw AuthenticationErrorCode.RESOURCE_SERVER_UNAVAILABLE.toException();
+        }
+    }
+
+    private MultiValueMap<String, String> createAccessTokenRequestBody(String authCode) {
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add("client_id", kakaoOAuthProperty.getClientId());
+        parameters.add("client_secret", kakaoOAuthProperty.getClientSecret());
+        parameters.add("code", authCode);
+        parameters.add("grant_type", GRANT_TYPE);
+        parameters.add("redirect_uri", kakaoOAuthProperty.getRedirectUri());
+        return parameters;
+    }
+}

--- a/src/main/java/spring/backend/auth/infrastructure/kakao/dto/KakaoResourceResponse.java
+++ b/src/main/java/spring/backend/auth/infrastructure/kakao/dto/KakaoResourceResponse.java
@@ -1,0 +1,26 @@
+package spring.backend.auth.infrastructure.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+@Getter
+public class KakaoResourceResponse {
+
+    private Long id;
+
+    @JsonProperty("kakao_account")
+    private Response kakaoAccount;
+
+    @Getter
+    public static class Response {
+
+        private String email;
+
+        private Profile profile;
+
+        @Getter
+        public static class Profile {
+            private String nickname;
+        }
+    }
+}

--- a/src/main/java/spring/backend/auth/infrastructure/naver/NaverOAuthRestClient.java
+++ b/src/main/java/spring/backend/auth/infrastructure/naver/NaverOAuthRestClient.java
@@ -1,0 +1,110 @@
+package spring.backend.auth.infrastructure.naver;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import spring.backend.auth.dto.response.OAuthAccessTokenResponse;
+import spring.backend.auth.dto.response.OAuthResourceResponse;
+import spring.backend.auth.exception.AuthenticationErrorCode;
+import spring.backend.auth.infrastructure.OAuthRestClient;
+import spring.backend.auth.infrastructure.naver.dto.NaverResourceResponse;
+import spring.backend.core.configuration.property.NaverOAuthProperty;
+
+import java.math.BigInteger;
+import java.net.URI;
+import java.security.SecureRandom;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class NaverOAuthRestClient implements OAuthRestClient {
+
+    private static final String GRANT_TYPE = "authorization_code";
+
+    private final NaverOAuthProperty naverOAuthProperty;
+
+    @Override
+    public URI getAuthUrl() {
+        return UriComponentsBuilder.fromUriString(naverOAuthProperty.getAuthUri())
+                .queryParam("client_id", naverOAuthProperty.getClientId())
+                .queryParam("redirect_uri", naverOAuthProperty.getRedirectUri())
+                .queryParam("response_type", "code")
+                .queryParam("state", generateState())
+                .build()
+                .toUri();
+    }
+
+    @Override
+    public OAuthAccessTokenResponse getAccessToken(String authCode, String state) {
+        if (authCode == null || authCode.isEmpty() || state == null || state.isEmpty()) {
+            log.error("[NaverOAuthProperty] authCode is null");
+            throw AuthenticationErrorCode.NOT_EXIST_AUTH_CODE.toException();
+        }
+        try {
+            return RestClient.create()
+                    .post()
+                    .uri(naverOAuthProperty.getTokenUri())
+                    .headers(header -> header.setContentType(MediaType.APPLICATION_FORM_URLENCODED))
+                    .body(createAccessTokenRequestBody(authCode, state))
+                    .retrieve()
+                    .body(OAuthAccessTokenResponse.class);
+        } catch (Exception e) {
+            log.error("[NaverOAuthProperty] error", e);
+            throw AuthenticationErrorCode.ACCESS_TOKEN_NOT_ISSUED.toException();
+        }
+    }
+
+    @Override
+    public OAuthResourceResponse getResource(String oauthToken) {
+        if (oauthToken == null || oauthToken.isEmpty()) {
+            log.error("[NaverOAuthProperty] oauthToken is null");
+            throw AuthenticationErrorCode.NOT_EXIST_AUTH_CODE.toException();
+        }
+        try {
+            NaverResourceResponse naverResourceResponse = RestClient.create()
+                    .get()
+                    .uri(naverOAuthProperty.getResourceUri())
+                    .headers(header -> {
+                        header.setBearerAuth(oauthToken);
+                        header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                    })
+                    .retrieve()
+                    .body(NaverResourceResponse.class);
+
+            if (naverResourceResponse == null) {
+                throw AuthenticationErrorCode.NOT_EXIST_RESOURCE_RESPONSE.toException();
+            }
+            NaverResourceResponse.Response resourceResponse = naverResourceResponse.getResponse();
+            if (resourceResponse == null || resourceResponse.getId() == null || resourceResponse.getName() == null || resourceResponse.getEmail() == null) {
+                throw AuthenticationErrorCode.NOT_EXIST_RESOURCE_RESPONSE.toException();
+            }
+            return OAuthResourceResponse.builder()
+                    .id(resourceResponse.getId())
+                    .name(resourceResponse.getName())
+                    .email(resourceResponse.getEmail())
+                    .build();
+        } catch (Exception e) {
+            throw AuthenticationErrorCode.RESOURCE_SERVER_UNAVAILABLE.toException();
+        }
+    }
+
+    private String generateState() {
+        SecureRandom random = new SecureRandom();
+        return new BigInteger(130, random).toString(32);
+    }
+
+    private MultiValueMap<String, String> createAccessTokenRequestBody(String authCode, String state) {
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.add("client_id", naverOAuthProperty.getClientId());
+        parameters.add("client_secret", naverOAuthProperty.getClientSecret());
+        parameters.add("grant_type", GRANT_TYPE);
+        parameters.add("state", state);
+        parameters.add("code", authCode);
+        return parameters;
+    }
+}

--- a/src/main/java/spring/backend/auth/infrastructure/naver/dto/NaverResourceResponse.java
+++ b/src/main/java/spring/backend/auth/infrastructure/naver/dto/NaverResourceResponse.java
@@ -1,0 +1,16 @@
+package spring.backend.auth.infrastructure.naver.dto;
+
+import lombok.Getter;
+
+@Getter
+public class NaverResourceResponse {
+
+    private Response response;
+
+    @Getter
+    public static class Response {
+        private String id;
+        private String name;
+        private String email;
+    }
+}

--- a/src/main/java/spring/backend/auth/presentation/AuthorizeOAuthController.java
+++ b/src/main/java/spring/backend/auth/presentation/AuthorizeOAuthController.java
@@ -1,0 +1,25 @@
+package spring.backend.auth.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.view.RedirectView;
+import spring.backend.auth.application.AuthorizeOAuthService;
+
+import java.net.URI;
+
+@Controller
+@RequestMapping("/v1/oauth")
+@RequiredArgsConstructor
+public class AuthorizeOAuthController {
+
+    private final AuthorizeOAuthService authorizeOAuthService;
+
+    @GetMapping("/{providerName}")
+    public RedirectView authorizeOAuth(@PathVariable String providerName) {
+        URI authUrl = authorizeOAuthService.getAuthorizeUrl(providerName);
+        return new RedirectView(authUrl.toASCIIString());
+    }
+}

--- a/src/main/java/spring/backend/auth/presentation/HandleOAuthLoginController.java
+++ b/src/main/java/spring/backend/auth/presentation/HandleOAuthLoginController.java
@@ -1,0 +1,24 @@
+package spring.backend.auth.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import spring.backend.auth.application.HandleOAuthLoginService;
+import spring.backend.auth.dto.response.LoginResponse;
+import spring.backend.core.presentation.RestResponse;
+
+@RestController
+@RequestMapping("/v1/oauth/login")
+@RequiredArgsConstructor
+public class HandleOAuthLoginController {
+
+    private final HandleOAuthLoginService handleOAuthLoginService;
+
+    @GetMapping("/{providerName}")
+    public ResponseEntity<RestResponse<LoginResponse>> handleOAuthLogin(@RequestParam(value = "code", required = false) String code,
+                                                                        @RequestParam(value = "state", required = false) String state,
+                                                                        @PathVariable String providerName) {
+        LoginResponse loginResponse = handleOAuthLoginService.handleOAuthLogin(providerName, code, state);
+        return ResponseEntity.ok(new RestResponse<>(loginResponse));
+    }
+}

--- a/src/main/java/spring/backend/core/configuration/property/GoogleOAuthProperty.java
+++ b/src/main/java/spring/backend/core/configuration/property/GoogleOAuthProperty.java
@@ -1,0 +1,14 @@
+package spring.backend.core.configuration.property;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import spring.backend.core.configuration.property.shared.BaseOAuthProperty;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties("oauth2.google")
+public class GoogleOAuthProperty extends BaseOAuthProperty {
+}

--- a/src/main/java/spring/backend/core/configuration/property/KakaoOAuthProperty.java
+++ b/src/main/java/spring/backend/core/configuration/property/KakaoOAuthProperty.java
@@ -1,0 +1,14 @@
+package spring.backend.core.configuration.property;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import spring.backend.core.configuration.property.shared.BaseOAuthProperty;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties("oauth2.kakao")
+public class KakaoOAuthProperty extends BaseOAuthProperty {
+}

--- a/src/main/java/spring/backend/core/configuration/property/NaverOAuthProperty.java
+++ b/src/main/java/spring/backend/core/configuration/property/NaverOAuthProperty.java
@@ -1,0 +1,14 @@
+package spring.backend.core.configuration.property;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import spring.backend.core.configuration.property.shared.BaseOAuthProperty;
+
+@Component
+@Getter
+@Setter
+@ConfigurationProperties("oauth2.naver")
+public class NaverOAuthProperty extends BaseOAuthProperty {
+}

--- a/src/main/java/spring/backend/core/configuration/property/shared/BaseOAuthProperty.java
+++ b/src/main/java/spring/backend/core/configuration/property/shared/BaseOAuthProperty.java
@@ -1,0 +1,25 @@
+package spring.backend.core.configuration.property.shared;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Set;
+
+@Getter
+@Setter
+public class BaseOAuthProperty {
+
+    protected String clientId;
+
+    protected String clientSecret;
+
+    protected String redirectUri;
+
+    protected Set<String> scope;
+
+    protected String tokenUri;
+
+    protected String resourceUri;
+
+    protected String authUri;
+}

--- a/src/main/java/spring/backend/core/exception/AuthenticationException.java
+++ b/src/main/java/spring/backend/core/exception/AuthenticationException.java
@@ -1,0 +1,8 @@
+package spring.backend.core.exception;
+
+public class AuthenticationException extends RuntimeException {
+
+    public AuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/spring/backend/core/infrastructure/jpa/shared/BaseEntity.java
+++ b/src/main/java/spring/backend/core/infrastructure/jpa/shared/BaseEntity.java
@@ -1,0 +1,32 @@
+package spring.backend.core.infrastructure.jpa.shared;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = AuditingEntityListener.class)
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    protected UUID id;
+
+    @CreatedDate
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    protected LocalDateTime updatedAt;
+
+    @Builder.Default
+    protected Boolean deleted = false;
+}

--- a/src/main/java/spring/backend/member/application/CreateMemberWithOAuthService.java
+++ b/src/main/java/spring/backend/member/application/CreateMemberWithOAuthService.java
@@ -1,0 +1,41 @@
+package spring.backend.member.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.repository.MemberRepository;
+import spring.backend.member.domain.value.Role;
+import spring.backend.member.dto.request.CreateMemberWithOAuthRequest;
+import spring.backend.member.exception.MemberErrorCode;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class CreateMemberWithOAuthService {
+
+    private final MemberRepository memberRepository;
+
+    public Member createMemberWithOAuth(CreateMemberWithOAuthRequest request) {
+        if (request == null) {
+            log.error("[createMemberWithOAuth] request is null");
+            throw MemberErrorCode.NOT_EXIST_CONDITION.toException();
+        }
+        Member member = memberRepository.findByEmail(request.getEmail());
+        if (member == null) {
+            Member newMember = Member.builder()
+                    .provider(request.getProvider())
+                    .role(Role.GUEST)
+                    .email(request.getEmail())
+                    .nickname(request.getNickname())
+                    .build();
+            memberRepository.save(newMember);
+            return newMember;
+        }
+        if (!member.isSameProvider(request.getProvider())) {
+            log.error("[createMemberWithOAuth] provider mismatch");
+            throw MemberErrorCode.ALREADY_EXIST_EMAIL.toException();
+        }
+        return member;
+    }
+}

--- a/src/main/java/spring/backend/member/application/CreateMemberWithOAuthService.java
+++ b/src/main/java/spring/backend/member/application/CreateMemberWithOAuthService.java
@@ -5,9 +5,10 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import spring.backend.member.domain.entity.Member;
 import spring.backend.member.domain.repository.MemberRepository;
-import spring.backend.member.domain.value.Role;
 import spring.backend.member.dto.request.CreateMemberWithOAuthRequest;
 import spring.backend.member.exception.MemberErrorCode;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,21 +22,30 @@ public class CreateMemberWithOAuthService {
             log.error("[createMemberWithOAuth] request is null");
             throw MemberErrorCode.NOT_EXIST_CONDITION.toException();
         }
-        Member member = memberRepository.findByEmail(request.getEmail());
-        if (member == null) {
-            Member newMember = Member.builder()
-                    .provider(request.getProvider())
-                    .role(Role.GUEST)
-                    .email(request.getEmail())
-                    .nickname(request.getNickname())
-                    .build();
+        List<Member> members = memberRepository.findAllByEmail(request.getEmail());
+        if (members == null || members.isEmpty()) {
+            Member newMember = Member.createGuestMember(request.getProvider(), request.getEmail(), request.getNickname());
             memberRepository.save(newMember);
             return newMember;
         }
-        if (!member.isSameProvider(request.getProvider())) {
-            log.error("[createMemberWithOAuth] provider mismatch");
-            throw MemberErrorCode.ALREADY_EXIST_EMAIL.toException();
+        Member existingMember = members.stream()
+                .filter(Member::isMember)
+                .findFirst()
+                .orElse(null);
+        if (existingMember != null) {
+            if (!existingMember.isSameProvider(request.getProvider())) {
+                log.error("[CreateMemberWithOAuthService] member already exists with a different provider [{}]", existingMember.getProvider());
+                throw MemberErrorCode.ALREADY_REGISTERED_WITH_DIFFERENT_OAUTH2.toException();
+            }
+            return existingMember;
         }
-        return member;
+        return members.stream()
+                .filter(m -> m.isSameProvider(request.getProvider()))
+                .findFirst()
+                .orElseGet(() -> {
+                    Member newMember = Member.createGuestMember(request.getProvider(), request.getEmail(), request.getNickname());
+                    memberRepository.save(newMember);
+                    return newMember;
+                });
     }
 }

--- a/src/main/java/spring/backend/member/domain/entity/Member.java
+++ b/src/main/java/spring/backend/member/domain/entity/Member.java
@@ -45,4 +45,17 @@ public class Member {
     public boolean isSameProvider(Provider otherProvider) {
         return this.provider.equals(otherProvider);
     }
+
+    public boolean isMember() {
+        return Role.MEMBER.equals(this.role);
+    }
+
+    public static Member createGuestMember(Provider provider, String email, String nickname) {
+        return Member.builder()
+                .provider(provider)
+                .role(Role.GUEST)
+                .email(email)
+                .nickname(nickname)
+                .build();
+    }
 }

--- a/src/main/java/spring/backend/member/domain/entity/Member.java
+++ b/src/main/java/spring/backend/member/domain/entity/Member.java
@@ -1,0 +1,48 @@
+package spring.backend.member.domain.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import spring.backend.member.domain.value.Provider;
+import spring.backend.member.domain.value.Role;
+import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class Member {
+
+    private final UUID id;
+
+    private final Provider provider;
+
+    private final Role role;
+
+    private final String email;
+
+    private final String nickname;
+
+    private final LocalDateTime createdAt;
+
+    private final LocalDateTime updatedAt;
+
+    private final Boolean deleted;
+
+    public static Member toDomainEntity(MemberJpaEntity memberJpaEntity) {
+        return Member.builder()
+                .id(memberJpaEntity.getId())
+                .provider(memberJpaEntity.getProvider())
+                .role(memberJpaEntity.getRole())
+                .email(memberJpaEntity.getEmail())
+                .nickname(memberJpaEntity.getNickname())
+                .createdAt(memberJpaEntity.getCreatedAt())
+                .updatedAt(memberJpaEntity.getUpdatedAt())
+                .deleted(memberJpaEntity.getDeleted())
+                .build();
+    }
+
+    public boolean isSameProvider(Provider otherProvider) {
+        return this.provider.equals(otherProvider);
+    }
+}

--- a/src/main/java/spring/backend/member/domain/repository/MemberRepository.java
+++ b/src/main/java/spring/backend/member/domain/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package spring.backend.member.domain.repository;
 
 import spring.backend.member.domain.entity.Member;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface MemberRepository {
@@ -9,4 +10,5 @@ public interface MemberRepository {
     Member findById(UUID id);
     void save(Member member);
     Member findByEmail(String email);
+    List<Member> findAllByEmail(String email);
 }

--- a/src/main/java/spring/backend/member/domain/repository/MemberRepository.java
+++ b/src/main/java/spring/backend/member/domain/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package spring.backend.member.domain.repository;
+
+import spring.backend.member.domain.entity.Member;
+
+import java.util.UUID;
+
+public interface MemberRepository {
+
+    Member findById(UUID id);
+    void save(Member member);
+    Member findByEmail(String email);
+}

--- a/src/main/java/spring/backend/member/domain/value/Provider.java
+++ b/src/main/java/spring/backend/member/domain/value/Provider.java
@@ -1,0 +1,8 @@
+package spring.backend.member.domain.value;
+
+import lombok.Getter;
+
+@Getter
+public enum Provider {
+    GOOGLE, NAVER, KAKAO
+}

--- a/src/main/java/spring/backend/member/domain/value/Role.java
+++ b/src/main/java/spring/backend/member/domain/value/Role.java
@@ -1,0 +1,8 @@
+package spring.backend.member.domain.value;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+    MEMBER, GUEST
+}

--- a/src/main/java/spring/backend/member/dto/request/CreateMemberWithOAuthRequest.java
+++ b/src/main/java/spring/backend/member/dto/request/CreateMemberWithOAuthRequest.java
@@ -1,0 +1,16 @@
+package spring.backend.member.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import spring.backend.member.domain.value.Provider;
+
+@Getter
+@Builder
+public class CreateMemberWithOAuthRequest {
+
+    private final Provider provider;
+
+    private final String email;
+
+    private final String nickname;
+}

--- a/src/main/java/spring/backend/member/exception/MemberErrorCode.java
+++ b/src/main/java/spring/backend/member/exception/MemberErrorCode.java
@@ -1,0 +1,25 @@
+package spring.backend.member.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import spring.backend.core.exception.DomainException;
+import spring.backend.core.exception.error.BaseErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_EXIST_CONDITION(HttpStatus.BAD_REQUEST, "요청 조건이 존재하지 않습니다."),
+    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일의 회원이 있습니다."),
+    MEMBER_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 정보를 저장하는데 실패하였습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+        return new DomainException(httpStatus, this);
+    }
+}

--- a/src/main/java/spring/backend/member/exception/MemberErrorCode.java
+++ b/src/main/java/spring/backend/member/exception/MemberErrorCode.java
@@ -11,7 +11,7 @@ import spring.backend.core.exception.error.BaseErrorCode;
 public enum MemberErrorCode implements BaseErrorCode<DomainException> {
 
     NOT_EXIST_CONDITION(HttpStatus.BAD_REQUEST, "요청 조건이 존재하지 않습니다."),
-    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일의 회원이 있습니다."),
+    ALREADY_REGISTERED_WITH_DIFFERENT_OAUTH2(HttpStatus.BAD_REQUEST, "이미 다른 소셜 로그인으로 가입된 계정입니다."),
     MEMBER_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 정보를 저장하는데 실패하였습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/spring/backend/member/infrastructure/mapper/MemberMapper.java
+++ b/src/main/java/spring/backend/member/infrastructure/mapper/MemberMapper.java
@@ -1,0 +1,17 @@
+package spring.backend.member.infrastructure.mapper;
+
+import org.springframework.stereotype.Component;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
+
+@Component
+public class MemberMapper {
+
+    public Member toDomainEntity(MemberJpaEntity member) {
+        return Member.toDomainEntity(member);
+    }
+
+    public MemberJpaEntity toJpaEntity(Member member) {
+        return MemberJpaEntity.toJpaEntity(member);
+    }
+}

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/adapter/MemberRepositoryImpl.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/adapter/MemberRepositoryImpl.java
@@ -10,7 +10,9 @@ import spring.backend.member.infrastructure.mapper.MemberMapper;
 import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
 import spring.backend.member.infrastructure.persistence.jpa.repository.MemberJpaRepository;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -45,5 +47,14 @@ public class MemberRepositoryImpl implements MemberRepository {
             return null;
         }
         return memberMapper.toDomainEntity(memberJpaEntity);
+    }
+
+    @Override
+    public List<Member> findAllByEmail(String email) {
+        List<MemberJpaEntity> memberJpaEntities = memberJpaRepository.findAllByEmail(email);
+        if (memberJpaEntities == null || memberJpaEntities.isEmpty()) {
+            return null;
+        }
+        return memberJpaEntities.stream().map(memberMapper::toDomainEntity).collect(Collectors.toList());
     }
 }

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/adapter/MemberRepositoryImpl.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/adapter/MemberRepositoryImpl.java
@@ -1,0 +1,49 @@
+package spring.backend.member.infrastructure.persistence.jpa.adapter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Repository;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.repository.MemberRepository;
+import spring.backend.member.exception.MemberErrorCode;
+import spring.backend.member.infrastructure.mapper.MemberMapper;
+import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
+import spring.backend.member.infrastructure.persistence.jpa.repository.MemberJpaRepository;
+
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+@Log4j2
+public class MemberRepositoryImpl implements MemberRepository {
+
+    private final MemberMapper memberMapper;
+    private final MemberJpaRepository memberJpaRepository;
+
+    @Override
+    public Member findById(UUID id) {
+        MemberJpaEntity memberJpaEntity = memberJpaRepository.findById(id).orElse(null);
+        if (memberJpaEntity == null) {
+            return null;
+        }
+        return memberMapper.toDomainEntity(memberJpaEntity);
+    }
+
+    @Override
+    public void save(Member member) {
+        MemberJpaEntity memberJpaEntity = memberMapper.toJpaEntity(member);
+        if (memberJpaEntity == null) {
+            throw MemberErrorCode.MEMBER_SAVE_FAILED.toException();
+        }
+        memberJpaRepository.save(memberJpaEntity);
+    }
+
+    @Override
+    public Member findByEmail(String email) {
+        MemberJpaEntity memberJpaEntity = memberJpaRepository.findByEmail(email);
+        if (memberJpaEntity == null) {
+            return null;
+        }
+        return memberMapper.toDomainEntity(memberJpaEntity);
+    }
+}

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/entity/MemberJpaEntity.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/entity/MemberJpaEntity.java
@@ -1,0 +1,47 @@
+package spring.backend.member.infrastructure.persistence.jpa.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import spring.backend.core.infrastructure.jpa.shared.BaseEntity;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.value.Provider;
+import spring.backend.member.domain.value.Role;
+
+import java.util.Optional;
+
+@Entity
+@Table(name = "member")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberJpaEntity extends BaseEntity {
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    private String email;
+
+    private String nickname;
+
+    public static MemberJpaEntity toJpaEntity(Member member) {
+        return MemberJpaEntity.builder()
+                .id(member.getId())
+                .provider(member.getProvider())
+                .role(member.getRole())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .createdAt(member.getCreatedAt())
+                .updatedAt(member.getUpdatedAt())
+                .deleted(Optional.ofNullable(member.getDeleted()).orElse(false))
+                .build();
+    }
+}

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/repository/MemberJpaRepository.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/repository/MemberJpaRepository.java
@@ -3,9 +3,12 @@ package spring.backend.member.infrastructure.persistence.jpa.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, UUID> {
 
     MemberJpaEntity findByEmail(String email);
+
+    List<MemberJpaEntity> findAllByEmail(String email);
 }

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/repository/MemberJpaRepository.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/repository/MemberJpaRepository.java
@@ -1,0 +1,11 @@
+package spring.backend.member.infrastructure.persistence.jpa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
+
+import java.util.UUID;
+
+public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, UUID> {
+
+    MemberJpaEntity findByEmail(String email);
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

### 우선 죄송합니다ㅜㅜ
- 작업을 작은 단위로 쪼개서 PR 작업을 진행하고 싶었는데 구글, 네이버, 카카오를 나눠서 작업을 하면 좋았겠지만, 대부분 겹치는 코드가 많아서 한번에 진행했습니다..
- 커밋을 세세하게 나누긴 했는데 그래도 저희 목표가 작업 크기를 작게 하는게 목표이니 의도적으로 계속 줄여보겠습니다.
- 커밋 별로 봐주시면 좋을 거 같습니다! 

### 작업 흐름
![스크린샷 2024-10-14 오전 4 11 17](https://github.com/user-attachments/assets/c0e53c5d-2d67-4234-9c97-25d7a1a0327d)

- 구글, 네이버, 카카오 모두 써드파티의 인증 서버인데 사진과 같이 플로우는 
  - 사용자가 로그인 요청을 한다. 
  - 서버에서 써드파티 인증 서버에 인증 처리를 거쳐 인가 코드를 받는다. (`AuthorizeOAuthController`)
  - 인가 코드를 가지고 써드파티에서 제공하는 토큰과 자원 서버에서 사용자 정보를 받는다. (`HandleOAuthLoginController`)

이런 식으로 진행됩니다.

제가 여기서 덧붙여서 생각했던 지점은
- 사용자가 로그인 요청을 한다. 
- 서버에서 써드파티 인증 서버에 인증 처리를 거쳐 인가 코드를 받는다. (`AuthorizeOAuthController`)
- 인가 코드를 가지고 써드파티에서 제공하는 토큰과 자원 서버에서 사용자 정보를 받는다. (`HandleOAuthLoginController`)
- 사용자 정보까지 다 받았을 때 (로그인 성공했을 때)
  - 회원이 존재하지 않으면 사용자 정보를 가지고 임시 회원 저장을 한다. 
    - 이유 : 아직 기획 측에서 내용이 안나왔지만, 추가적으로 사용자 정보를 입력받아 회원 가입을 할 것으로 보였기 때문입니다.
    - 따라서 임시 회원가입을 하고, 사용자 Role을 추가해서 Member(회원), Guest(임시)로 나눠봤습니다.
    - 로그인 성공 응답으로 `accessToken` 과 `refreshToken` 을 제공한다.
- 이후 추가적인 회원 가입 플로우를 따라서 사용자 정보를 다 입력 받았을 때, PUT이나 PATCH를 통해 사용자 정보를 추가하고, Role또한 변경하는 플로우로 생각해봤습니다.

### 못한 부분
JWT와 추가적인 회원가입 진행 관련 API 작업은 하지 않았습니다. 해당 PR에서는 소셜 로그인만 진행하고 이슈 파서 다른 작업으로 만들어야할 것 같습니다.

호영이형이 작업 다 끝난 거 같아서 추후 작업 방향 논의해보면 좋을 거 같습니다!

### 무조건 기억해야할 부분
- `HandleOAuthLoginController` 이 API에서 제 생각은 토큰을 응답으로 반환하는 거였습니다.
- 이 부분에 대해서 어떻게 할지 논의가 필요해 보여서, 우선 LoginResponse 응답 객체는 놔두고, `HandleOAuthLoginService`단에서 null을 임시로 반환하였습니다. (주석 포함)

- application-local.yml 수정본 노션에 업데이트했습니다!

![스크린샷 2024-10-14 오전 4 26 10](https://github.com/user-attachments/assets/0caedfb3-d4f7-462e-8f90-99b746b710b9)
![스크린샷 2024-10-14 오전 4 26 19](https://github.com/user-attachments/assets/57a1cc81-293c-4005-9086-0efce618e0c3)
![스크린샷 2024-10-14 오전 4 26 26](https://github.com/user-attachments/assets/2401dc4d-4d41-45eb-ada4-25c50f7c731a)

---

## ✏️ 관련 이슈
- Resolves : #13 


---

## 🎸 기타 사항 or 추가 코멘트
- 제가 생각했던 플로우 한번 읽어보시고 피드백이나 궁금한점 언제든지 환영입니다!!!
- 회원가입하면서 사용자가 필요해서 사용자 도메인 만들었는데 이거는 다른 이슈 파서 올릴 예정입니다.