### PR TITLE
Feat: (#15) 회원가입을 위한 사용자 도메인을 생성한다.

### DIFF
--- a/src/main/java/spring/backend/BackendApplication.java
+++ b/src/main/java/spring/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package spring.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/spring/backend/core/infrastructure/jpa/shared/BaseEntity.java
+++ b/src/main/java/spring/backend/core/infrastructure/jpa/shared/BaseEntity.java
@@ -1,0 +1,32 @@
+package spring.backend.core.infrastructure.jpa.shared;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = AuditingEntityListener.class)
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    protected UUID id;
+
+    @CreatedDate
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    protected LocalDateTime updatedAt;
+
+    @Builder.Default
+    protected Boolean deleted = false;
+}

--- a/src/main/java/spring/backend/member/application/CreateMemberWithOAuthService.java
+++ b/src/main/java/spring/backend/member/application/CreateMemberWithOAuthService.java
@@ -1,0 +1,41 @@
+package spring.backend.member.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.repository.MemberRepository;
+import spring.backend.member.domain.value.Role;
+import spring.backend.member.dto.request.CreateMemberWithOAuthRequest;
+import spring.backend.member.exception.MemberErrorCode;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class CreateMemberWithOAuthService {
+
+    private final MemberRepository memberRepository;
+
+    public Member createMemberWithOAuth(CreateMemberWithOAuthRequest request) {
+        if (request == null) {
+            log.error("[createMemberWithOAuth] request is null");
+            throw MemberErrorCode.NOT_EXIST_CONDITION.toException();
+        }
+        Member member = memberRepository.findByEmail(request.getEmail());
+        if (member == null) {
+            Member newMember = Member.builder()
+                    .provider(request.getProvider())
+                    .role(Role.GUEST)
+                    .email(request.getEmail())
+                    .nickname(request.getNickname())
+                    .build();
+            memberRepository.save(newMember);
+            return newMember;
+        }
+        if (!member.isSameProvider(request.getProvider())) {
+            log.error("[createMemberWithOAuth] provider mismatch");
+            throw MemberErrorCode.ALREADY_EXIST_EMAIL.toException();
+        }
+        return member;
+    }
+}

--- a/src/main/java/spring/backend/member/application/CreateMemberWithOAuthService.java
+++ b/src/main/java/spring/backend/member/application/CreateMemberWithOAuthService.java
@@ -5,9 +5,10 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import spring.backend.member.domain.entity.Member;
 import spring.backend.member.domain.repository.MemberRepository;
-import spring.backend.member.domain.value.Role;
 import spring.backend.member.dto.request.CreateMemberWithOAuthRequest;
 import spring.backend.member.exception.MemberErrorCode;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,21 +22,30 @@ public class CreateMemberWithOAuthService {
             log.error("[createMemberWithOAuth] request is null");
             throw MemberErrorCode.NOT_EXIST_CONDITION.toException();
         }
-        Member member = memberRepository.findByEmail(request.getEmail());
-        if (member == null) {
-            Member newMember = Member.builder()
-                    .provider(request.getProvider())
-                    .role(Role.GUEST)
-                    .email(request.getEmail())
-                    .nickname(request.getNickname())
-                    .build();
+        List<Member> members = memberRepository.findAllByEmail(request.getEmail());
+        if (members == null || members.isEmpty()) {
+            Member newMember = Member.createGuestMember(request.getProvider(), request.getEmail(), request.getNickname());
             memberRepository.save(newMember);
             return newMember;
         }
-        if (!member.isSameProvider(request.getProvider())) {
-            log.error("[createMemberWithOAuth] provider mismatch");
-            throw MemberErrorCode.ALREADY_EXIST_EMAIL.toException();
+        Member existingMember = members.stream()
+                .filter(Member::isMember)
+                .findFirst()
+                .orElse(null);
+        if (existingMember != null) {
+            if (!existingMember.isSameProvider(request.getProvider())) {
+                log.error("[CreateMemberWithOAuthService] member already exists with a different provider [{}]", existingMember.getProvider());
+                throw MemberErrorCode.ALREADY_REGISTERED_WITH_DIFFERENT_OAUTH2.toException();
+            }
+            return existingMember;
         }
-        return member;
+        return members.stream()
+                .filter(m -> m.isSameProvider(request.getProvider()))
+                .findFirst()
+                .orElseGet(() -> {
+                    Member newMember = Member.createGuestMember(request.getProvider(), request.getEmail(), request.getNickname());
+                    memberRepository.save(newMember);
+                    return newMember;
+                });
     }
 }

--- a/src/main/java/spring/backend/member/domain/entity/Member.java
+++ b/src/main/java/spring/backend/member/domain/entity/Member.java
@@ -45,4 +45,17 @@ public class Member {
     public boolean isSameProvider(Provider otherProvider) {
         return this.provider.equals(otherProvider);
     }
+
+    public boolean isMember() {
+        return Role.MEMBER.equals(this.role);
+    }
+
+    public static Member createGuestMember(Provider provider, String email, String nickname) {
+        return Member.builder()
+                .provider(provider)
+                .role(Role.GUEST)
+                .email(email)
+                .nickname(nickname)
+                .build();
+    }
 }

--- a/src/main/java/spring/backend/member/domain/entity/Member.java
+++ b/src/main/java/spring/backend/member/domain/entity/Member.java
@@ -1,0 +1,48 @@
+package spring.backend.member.domain.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import spring.backend.member.domain.value.Provider;
+import spring.backend.member.domain.value.Role;
+import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class Member {
+
+    private final UUID id;
+
+    private final Provider provider;
+
+    private final Role role;
+
+    private final String email;
+
+    private final String nickname;
+
+    private final LocalDateTime createdAt;
+
+    private final LocalDateTime updatedAt;
+
+    private final Boolean deleted;
+
+    public static Member toDomainEntity(MemberJpaEntity memberJpaEntity) {
+        return Member.builder()
+                .id(memberJpaEntity.getId())
+                .provider(memberJpaEntity.getProvider())
+                .role(memberJpaEntity.getRole())
+                .email(memberJpaEntity.getEmail())
+                .nickname(memberJpaEntity.getNickname())
+                .createdAt(memberJpaEntity.getCreatedAt())
+                .updatedAt(memberJpaEntity.getUpdatedAt())
+                .deleted(memberJpaEntity.getDeleted())
+                .build();
+    }
+
+    public boolean isSameProvider(Provider otherProvider) {
+        return this.provider.equals(otherProvider);
+    }
+}

--- a/src/main/java/spring/backend/member/domain/repository/MemberRepository.java
+++ b/src/main/java/spring/backend/member/domain/repository/MemberRepository.java
@@ -2,6 +2,7 @@ package spring.backend.member.domain.repository;
 
 import spring.backend.member.domain.entity.Member;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface MemberRepository {
@@ -9,4 +10,5 @@ public interface MemberRepository {
     Member findById(UUID id);
     void save(Member member);
     Member findByEmail(String email);
+    List<Member> findAllByEmail(String email);
 }

--- a/src/main/java/spring/backend/member/domain/repository/MemberRepository.java
+++ b/src/main/java/spring/backend/member/domain/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package spring.backend.member.domain.repository;
+
+import spring.backend.member.domain.entity.Member;
+
+import java.util.UUID;
+
+public interface MemberRepository {
+
+    Member findById(UUID id);
+    void save(Member member);
+    Member findByEmail(String email);
+}

--- a/src/main/java/spring/backend/member/domain/value/Provider.java
+++ b/src/main/java/spring/backend/member/domain/value/Provider.java
@@ -1,0 +1,8 @@
+package spring.backend.member.domain.value;
+
+import lombok.Getter;
+
+@Getter
+public enum Provider {
+    GOOGLE, NAVER, KAKAO
+}

--- a/src/main/java/spring/backend/member/domain/value/Role.java
+++ b/src/main/java/spring/backend/member/domain/value/Role.java
@@ -1,0 +1,8 @@
+package spring.backend.member.domain.value;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+    MEMBER, GUEST
+}

--- a/src/main/java/spring/backend/member/dto/request/CreateMemberWithOAuthRequest.java
+++ b/src/main/java/spring/backend/member/dto/request/CreateMemberWithOAuthRequest.java
@@ -1,0 +1,16 @@
+package spring.backend.member.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import spring.backend.member.domain.value.Provider;
+
+@Getter
+@Builder
+public class CreateMemberWithOAuthRequest {
+
+    private final Provider provider;
+
+    private final String email;
+
+    private final String nickname;
+}

--- a/src/main/java/spring/backend/member/exception/MemberErrorCode.java
+++ b/src/main/java/spring/backend/member/exception/MemberErrorCode.java
@@ -1,0 +1,25 @@
+package spring.backend.member.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import spring.backend.core.exception.DomainException;
+import spring.backend.core.exception.error.BaseErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements BaseErrorCode<DomainException> {
+
+    NOT_EXIST_CONDITION(HttpStatus.BAD_REQUEST, "요청 조건이 존재하지 않습니다."),
+    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일의 회원이 있습니다."),
+    MEMBER_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 정보를 저장하는데 실패하였습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+        return new DomainException(httpStatus, this);
+    }
+}

--- a/src/main/java/spring/backend/member/exception/MemberErrorCode.java
+++ b/src/main/java/spring/backend/member/exception/MemberErrorCode.java
@@ -11,7 +11,7 @@ import spring.backend.core.exception.error.BaseErrorCode;
 public enum MemberErrorCode implements BaseErrorCode<DomainException> {
 
     NOT_EXIST_CONDITION(HttpStatus.BAD_REQUEST, "요청 조건이 존재하지 않습니다."),
-    ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일의 회원이 있습니다."),
+    ALREADY_REGISTERED_WITH_DIFFERENT_OAUTH2(HttpStatus.BAD_REQUEST, "이미 다른 소셜 로그인으로 가입된 계정입니다."),
     MEMBER_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 정보를 저장하는데 실패하였습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/spring/backend/member/infrastructure/mapper/MemberMapper.java
+++ b/src/main/java/spring/backend/member/infrastructure/mapper/MemberMapper.java
@@ -1,0 +1,17 @@
+package spring.backend.member.infrastructure.mapper;
+
+import org.springframework.stereotype.Component;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
+
+@Component
+public class MemberMapper {
+
+    public Member toDomainEntity(MemberJpaEntity member) {
+        return Member.toDomainEntity(member);
+    }
+
+    public MemberJpaEntity toJpaEntity(Member member) {
+        return MemberJpaEntity.toJpaEntity(member);
+    }
+}

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/adapter/MemberRepositoryImpl.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/adapter/MemberRepositoryImpl.java
@@ -10,7 +10,9 @@ import spring.backend.member.infrastructure.mapper.MemberMapper;
 import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
 import spring.backend.member.infrastructure.persistence.jpa.repository.MemberJpaRepository;
 
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -45,5 +47,14 @@ public class MemberRepositoryImpl implements MemberRepository {
             return null;
         }
         return memberMapper.toDomainEntity(memberJpaEntity);
+    }
+
+    @Override
+    public List<Member> findAllByEmail(String email) {
+        List<MemberJpaEntity> memberJpaEntities = memberJpaRepository.findAllByEmail(email);
+        if (memberJpaEntities == null || memberJpaEntities.isEmpty()) {
+            return null;
+        }
+        return memberJpaEntities.stream().map(memberMapper::toDomainEntity).collect(Collectors.toList());
     }
 }

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/adapter/MemberRepositoryImpl.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/adapter/MemberRepositoryImpl.java
@@ -1,0 +1,49 @@
+package spring.backend.member.infrastructure.persistence.jpa.adapter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Repository;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.repository.MemberRepository;
+import spring.backend.member.exception.MemberErrorCode;
+import spring.backend.member.infrastructure.mapper.MemberMapper;
+import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
+import spring.backend.member.infrastructure.persistence.jpa.repository.MemberJpaRepository;
+
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+@Log4j2
+public class MemberRepositoryImpl implements MemberRepository {
+
+    private final MemberMapper memberMapper;
+    private final MemberJpaRepository memberJpaRepository;
+
+    @Override
+    public Member findById(UUID id) {
+        MemberJpaEntity memberJpaEntity = memberJpaRepository.findById(id).orElse(null);
+        if (memberJpaEntity == null) {
+            return null;
+        }
+        return memberMapper.toDomainEntity(memberJpaEntity);
+    }
+
+    @Override
+    public void save(Member member) {
+        MemberJpaEntity memberJpaEntity = memberMapper.toJpaEntity(member);
+        if (memberJpaEntity == null) {
+            throw MemberErrorCode.MEMBER_SAVE_FAILED.toException();
+        }
+        memberJpaRepository.save(memberJpaEntity);
+    }
+
+    @Override
+    public Member findByEmail(String email) {
+        MemberJpaEntity memberJpaEntity = memberJpaRepository.findByEmail(email);
+        if (memberJpaEntity == null) {
+            return null;
+        }
+        return memberMapper.toDomainEntity(memberJpaEntity);
+    }
+}

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/entity/MemberJpaEntity.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/entity/MemberJpaEntity.java
@@ -1,0 +1,47 @@
+package spring.backend.member.infrastructure.persistence.jpa.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import spring.backend.core.infrastructure.jpa.shared.BaseEntity;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.value.Provider;
+import spring.backend.member.domain.value.Role;
+
+import java.util.Optional;
+
+@Entity
+@Table(name = "member")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberJpaEntity extends BaseEntity {
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    private String email;
+
+    private String nickname;
+
+    public static MemberJpaEntity toJpaEntity(Member member) {
+        return MemberJpaEntity.builder()
+                .id(member.getId())
+                .provider(member.getProvider())
+                .role(member.getRole())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .createdAt(member.getCreatedAt())
+                .updatedAt(member.getUpdatedAt())
+                .deleted(Optional.ofNullable(member.getDeleted()).orElse(false))
+                .build();
+    }
+}

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/repository/MemberJpaRepository.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/repository/MemberJpaRepository.java
@@ -3,9 +3,12 @@ package spring.backend.member.infrastructure.persistence.jpa.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, UUID> {
 
     MemberJpaEntity findByEmail(String email);
+
+    List<MemberJpaEntity> findAllByEmail(String email);
 }

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/repository/MemberJpaRepository.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/repository/MemberJpaRepository.java
@@ -1,0 +1,11 @@
+package spring.backend.member.infrastructure.persistence.jpa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
+
+import java.util.UUID;
+
+public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, UUID> {
+
+    MemberJpaEntity findByEmail(String email);
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- DDD 방법론을 따라 최대한 설계해봤습니다.
  - 계층별 의존성을 낮추기 위해 최대한 사용자 도메인에서 의존을 갖게 하였습니다. (소셜로그인을 통한 사용자 생성도 인증, 인가 도메인에서 생성하는 것이 아닌 사용자 도메인에서 서비스를 만들어서 인증,인가 도메인에서 의존도를 낮출 수 있도록 함)
  - 도메인 계층에 Member와 인프라 계층에 JpaMemberEntity를 나눠 특정 기술에 의존되지 않으려고 하였습니다.
  - 리포지터리도 이와 같은 이유로 분리하였으며, 인프라 계층과 도메인 계층을 어댑터해주는 impl 구현 클래스 만들었습니다. ([참고](https://dev-coco.tistory.com/190))
---

## ✏️ 관련 이슈
- Resolves : #15
- Related to : #13 

---

## 🎸 기타 사항 or 추가 코멘트