### PR TITLE
chore: (#20) 모니터링 서버 구축을 위한 gradle 의존성을 추가한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,10 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// monitoring (Prometheus)
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

모니터링 서버로 백엔드 서버 측정값을 전달하기 위해선 의존성을 추가해야합니다. </br>
서버 측정값 전달을 위해 

```java
	implementation 'org.springframework.boot:spring-boot-starter-actuator'
```
를 추가했고,

현재 prometheus와 grafana를 통해 모니터링 서버를 구축 할 예정이기에 prometheus 용 의존성인 

```java
	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
```

를 추가했습니다. 

---

## ✏️ 관련 이슈

- Related to : #20 

---

## 🎸 기타 사항 or 추가 코멘트