### PR TITLE
Feat: 인터셉터에서 Authorization를 처리한다

### DIFF
--- a/src/main/java/spring/backend/auth/exception/AuthenticationErrorCode.java
+++ b/src/main/java/spring/backend/auth/exception/AuthenticationErrorCode.java
@@ -13,6 +13,7 @@ public enum AuthenticationErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_HEADER(HttpStatus.UNAUTHORIZED, "Authorization Header가 존재하지 않습니다."),
     NOT_EXIST_TOKEN(HttpStatus.UNAUTHORIZED, "Authorization Header에 Token이 존재하지 않습니다."),
     NOT_MATCH_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "토큰의 형식이 맞지 않습니다."),
+    INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "토큰의 서명이 올바르지 않습니다."),
     NOT_DEFINE_TOKEN(HttpStatus.UNAUTHORIZED, "정의되지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "유효한 OAuth 써드파티 제공자가 아닙니다."),

--- a/src/main/java/spring/backend/auth/exception/AuthenticationErrorCode.java
+++ b/src/main/java/spring/backend/auth/exception/AuthenticationErrorCode.java
@@ -3,17 +3,18 @@ package spring.backend.auth.exception;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import spring.backend.core.exception.AuthenticationException;
+import spring.backend.core.exception.DomainException;
 import spring.backend.core.exception.error.BaseErrorCode;
 
 @Getter
 @RequiredArgsConstructor
-public enum AuthenticationErrorCode implements BaseErrorCode<AuthenticationException> {
+public enum AuthenticationErrorCode implements BaseErrorCode<DomainException> {
 
     NOT_EXIST_HEADER(HttpStatus.UNAUTHORIZED, "Authorization Header가 존재하지 않습니다."),
     NOT_EXIST_TOKEN(HttpStatus.UNAUTHORIZED, "Authorization Header에 Token이 존재하지 않습니다."),
     NOT_MATCH_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "토큰의 형식이 맞지 않습니다."),
     NOT_DEFINE_TOKEN(HttpStatus.UNAUTHORIZED, "정의되지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "유효한 OAuth 써드파티 제공자가 아닙니다."),
     NOT_EXIST_PROVIDER(HttpStatus.BAD_REQUEST, "OAuth 써드파티 제공자가 존재하지 않습니다."),
     NOT_EXIST_AUTH_CODE(HttpStatus.BAD_GATEWAY, "OAuth 써드파티 제공자에서 제공받은 인증 코드가 존재하지 않습니다."),
@@ -26,7 +27,7 @@ public enum AuthenticationErrorCode implements BaseErrorCode<AuthenticationExcep
     private final String message;
 
     @Override
-    public AuthenticationException toException() {
-        return new AuthenticationException(message);
+    public DomainException toException() {
+        return new DomainException(httpStatus, this);
     }
 }

--- a/src/main/java/spring/backend/core/application/JwtService.java
+++ b/src/main/java/spring/backend/core/application/JwtService.java
@@ -78,6 +78,13 @@ public class JwtService {
         }
     }
 
+    public void validateTokenExpiration(String token) {
+        Claims claims = getPayload(token);
+        if (claims.getExpiration().before(new Date())) {
+            throw AuthenticationErrorCode.EXPIRED_TOKEN.toException();
+        }
+    }
+
     private String provideToken(String email, UUID id, Type type, long expiration) {
         Date expiryDate = Date.from(Instant.now().plus(expiration, ChronoUnit.DAYS));
         return Jwts.builder()

--- a/src/main/java/spring/backend/core/configuration/WebMvcConfiguration.java
+++ b/src/main/java/spring/backend/core/configuration/WebMvcConfiguration.java
@@ -1,0 +1,19 @@
+package spring.backend.core.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import spring.backend.core.configuration.interceptor.AuthorizationInterceptor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfiguration implements WebMvcConfigurer {
+
+    private final AuthorizationInterceptor authorizationInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authorizationInterceptor);
+    }
+}

--- a/src/main/java/spring/backend/core/configuration/interceptor/Authorization.java
+++ b/src/main/java/spring/backend/core/configuration/interceptor/Authorization.java
@@ -1,0 +1,11 @@
+package spring.backend.core.configuration.interceptor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authorization {
+}

--- a/src/main/java/spring/backend/core/configuration/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/spring/backend/core/configuration/interceptor/AuthorizationInterceptor.java
@@ -1,0 +1,52 @@
+package spring.backend.core.configuration.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+import spring.backend.auth.exception.AuthenticationErrorCode;
+import spring.backend.core.application.JwtService;
+
+import java.lang.annotation.Annotation;
+
+@Component
+@RequiredArgsConstructor
+public class AuthorizationInterceptor implements HandlerInterceptor {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    public static final String AUTHORIZATION_BEARER_PREFIX = "Bearer";
+
+    private final JwtService jwtService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        if (HttpMethod.OPTIONS.name().equals(request.getMethod())) {
+            return true;
+        }
+        String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+        if (handler instanceof HandlerMethod) {
+            HandlerMethod handlerMethod = (HandlerMethod) handler;
+            Annotation authorizationAnnotation = handlerMethod.getMethodAnnotation(Authorization.class);
+            if (authorizationAnnotation != null) {
+                String token = extractToken(authorizationHeader);
+                jwtService.validateTokenExpiration(token);
+            }
+        }
+        return true;
+    }
+
+    private String extractToken(String authorizationHeader) {
+        if (authorizationHeader == null) {
+            throw AuthenticationErrorCode.NOT_EXIST_HEADER.toException();
+        }
+        try {
+            return authorizationHeader.split(AUTHORIZATION_BEARER_PREFIX)[1].replace(" ", "");
+        } catch (Exception e) {
+            throw AuthenticationErrorCode.NOT_EXIST_TOKEN.toException();
+        }
+    }
+}

--- a/src/main/java/spring/backend/core/exception/AuthenticationException.java
+++ b/src/main/java/spring/backend/core/exception/AuthenticationException.java
@@ -1,8 +1,0 @@
-package spring.backend.core.exception;
-
-public class AuthenticationException extends RuntimeException {
-
-    public AuthenticationException(String message) {
-        super(message);
-    }
-}

--- a/src/test/java/spring/backend/BackendApplicationTests.java
+++ b/src/test/java/spring/backend/BackendApplicationTests.java
@@ -2,10 +2,8 @@ package spring.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("local")
 class BackendApplicationTests {
 
 	@Test

--- a/src/test/java/spring/backend/core/application/JwtServiceTest.java
+++ b/src/test/java/spring/backend/core/application/JwtServiceTest.java
@@ -1,0 +1,85 @@
+package spring.backend.core.application;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import spring.backend.auth.exception.AuthenticationErrorCode;
+import spring.backend.core.exception.DomainException;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class JwtServiceTest {
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Value("${jwt.secret}")
+    private String secret;
+    private String validJwt;
+    private String invalidJwt;
+    private String expiredJwt;
+
+    @BeforeEach
+    void setUp() {
+        long expirationTime = 1;
+        Date expiryDate = Date.from(Instant.now().plus(expirationTime, ChronoUnit.DAYS));
+        SecretKey secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+
+        validJwt = Jwts.builder()
+                .claim("name", "test")
+                .issuedAt(new Date())
+                .expiration(expiryDate)
+                .signWith(secretKey)
+                .compact();
+
+        invalidJwt = validJwt + "invalid";
+
+        expiryDate = Date.from(Instant.now().minus(expirationTime, ChronoUnit.DAYS));
+        expiredJwt = Jwts.builder()
+                .claim("name", "test")
+                .issuedAt(new Date())
+                .expiration(expiryDate)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    @DisplayName("유효한 JWT를 파싱하여 claim을 반환한다")
+    @Test
+    void getPayloadWithValidJwt() {
+        // when
+        Claims claims = jwtService.getPayload(validJwt);
+
+        // then
+        assertThat(claims.get("name")).isEqualTo("test");
+    }
+
+    @DisplayName("잘못된 JWT 형식일 경우 예외를 발생시킨다")
+    @Test
+    void getPayloadWithInvalidJwt() {
+        // when & then
+        DomainException ex = assertThrows(DomainException.class, () -> jwtService.getPayload(invalidJwt), "토큰의 형식이 맞지 않습니다.");
+        assertThat(ex.getCode()).isEqualTo(AuthenticationErrorCode.NOT_MATCH_TOKEN_FORMAT.name());
+    }
+
+    @DisplayName("만료된 토큰일 경우 예외를 발생시킨다")
+    @Test
+    void validateTokenExpirationWithExpiredJwt() {
+        // when & then
+        DomainException ex = assertThrows(DomainException.class, () -> jwtService.validateTokenExpiration(expiredJwt), "만료된 토큰입니다.");
+        assertThat(ex.getCode()).isEqualTo(AuthenticationErrorCode.EXPIRED_TOKEN.name());
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- Authorization을 처리하는 인터셉터를 추가하고, `@Authorization` 어노테이션을 추가하여 인증/인가가 필요한 API에 붙여 사용합니다.
- AuthenticationException을 DomainException과 분리하지 않아도 된다고 판단하여 제거하였습니다.
  - AuthenticationException이 401 UNAUTHORIZED만 반환한다면 따로 분리해서 생성해도 괜찮을 거 같은데 여러 에러 코드가 섞여있기 때문에 DomainException과 같은 동작을 하기 때문입니다.
- JwtService의 getPayload(), validateTokenExpiration() 메소드의 테스트를 작성하였습니다.

![스크린샷 2024-10-17 오전 12 19 15](https://github.com/user-attachments/assets/d3487ee9-5669-412b-8f72-491cc5fcc147)


---

## ✏️ 관련 이슈
- Resolves : #24 

---

## 🎸 기타 사항 or 추가 코멘트
### application.yml 수정했습니다!
- 토큰 생성 방식에서 우리는 초를 가지고 exp를 결정하는데 생성할 때 day 기준으로 계산을 해서 프로퍼티의 expiry 값을 day 기준으로 변경하였습니다.