### PR TITLE
Feat: (#32) ArgumentResolver에서 JWT 토큰을 멤버로 변환한다

### DIFF
--- a/src/main/java/spring/backend/core/application/JwtService.java
+++ b/src/main/java/spring/backend/core/application/JwtService.java
@@ -78,6 +78,11 @@ public class JwtService {
         }
     }
 
+    public UUID extractMemberId(String token) {
+        Claims claims = getPayload(token);
+        return UUID.fromString(claims.get("memberId", String.class));
+    }
+
     public void validateTokenExpiration(String token) {
         Claims claims = getPayload(token);
         if (claims.getExpiration().before(new Date())) {

--- a/src/main/java/spring/backend/core/configuration/WebMvcConfiguration.java
+++ b/src/main/java/spring/backend/core/configuration/WebMvcConfiguration.java
@@ -2,9 +2,13 @@ package spring.backend.core.configuration;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import spring.backend.core.configuration.argumentresolver.LoginMemberArgumentResolver;
 import spring.backend.core.configuration.interceptor.AuthorizationInterceptor;
+
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
@@ -12,8 +16,15 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
 
     private final AuthorizationInterceptor authorizationInterceptor;
 
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(authorizationInterceptor);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
     }
 }

--- a/src/main/java/spring/backend/core/configuration/argumentresolver/LoginMember.java
+++ b/src/main/java/spring/backend/core/configuration/argumentresolver/LoginMember.java
@@ -1,0 +1,11 @@
+package spring.backend.core.configuration.argumentresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMember {
+}

--- a/src/main/java/spring/backend/core/configuration/argumentresolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/spring/backend/core/configuration/argumentresolver/LoginMemberArgumentResolver.java
@@ -1,0 +1,53 @@
+package spring.backend.core.configuration.argumentresolver;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import spring.backend.auth.exception.AuthenticationErrorCode;
+import spring.backend.core.application.JwtService;
+import spring.backend.member.application.MemberService;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Log4j2
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    public static final String AUTHORIZATION_BEARER_PREFIX = "Bearer";
+
+    private final JwtService jwtService;
+
+    private final MemberService memberService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String authorizationHeader = webRequest.getHeader(AUTHORIZATION_HEADER);
+        String token = extractToken(authorizationHeader);
+        UUID memberId = jwtService.extractMemberId(token);
+        return memberService.findByMemberId(memberId);
+    }
+
+    private String extractToken(String authorizationHeader) {
+        if (authorizationHeader == null) {
+            throw AuthenticationErrorCode.NOT_EXIST_HEADER.toException();
+        }
+        try {
+            return authorizationHeader.split(AUTHORIZATION_BEARER_PREFIX)[1].replace(" ", "");
+        } catch (Exception e) {
+            throw AuthenticationErrorCode.NOT_EXIST_TOKEN.toException();
+        }
+    }
+}

--- a/src/main/java/spring/backend/member/application/MemberService.java
+++ b/src/main/java/spring/backend/member/application/MemberService.java
@@ -1,0 +1,22 @@
+package spring.backend.member.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.repository.MemberRepository;
+import spring.backend.member.exception.MemberErrorCode;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member findByMemberId(UUID memberId) {
+        Member member = memberRepository.findById(memberId);
+        return Optional.ofNullable(member).orElseThrow(MemberErrorCode.NOT_EXIST_MEMBER::toException);
+    }
+}

--- a/src/main/java/spring/backend/member/exception/MemberErrorCode.java
+++ b/src/main/java/spring/backend/member/exception/MemberErrorCode.java
@@ -12,7 +12,8 @@ public enum MemberErrorCode implements BaseErrorCode<DomainException> {
 
     NOT_EXIST_CONDITION(HttpStatus.BAD_REQUEST, "요청 조건이 존재하지 않습니다."),
     ALREADY_REGISTERED_WITH_DIFFERENT_OAUTH2(HttpStatus.BAD_REQUEST, "이미 다른 소셜 로그인으로 가입된 계정입니다."),
-    MEMBER_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 정보를 저장하는데 실패하였습니다.");
+    MEMBER_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 정보를 저장하는데 실패하였습니다."),
+    NOT_EXIST_MEMBER(HttpStatus.NOT_FOUND, "사용자가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/test/java/spring/backend/core/configuration/argumentresolver/LoginMemberArgumentResolverTest.java
+++ b/src/test/java/spring/backend/core/configuration/argumentresolver/LoginMemberArgumentResolverTest.java
@@ -1,0 +1,79 @@
+package spring.backend.core.configuration.argumentresolver;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import spring.backend.core.application.JwtService;
+import spring.backend.member.application.MemberService;
+import spring.backend.member.domain.entity.Member;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LoginMemberArgumentResolverTest {
+
+    @InjectMocks
+    private LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private NativeWebRequest webRequest;
+
+    @Mock
+    private ModelAndViewContainer mavContainer;
+
+    private UUID memberId;
+    private String token;
+    private Member member;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        memberId = UUID.randomUUID();
+        member = Member.builder()
+                .id(memberId)
+                .build();
+        token = jwtService.provideAccessToken(member);
+    }
+
+    @DisplayName("LoginMember 어노테이션이 있는 경우 지원한다")
+    @Test
+    public void supportsParameterReturnsTrueForLoginMember() {
+        MethodParameter parameter = mock(MethodParameter.class);
+        when(parameter.hasParameterAnnotation(LoginMember.class)).thenReturn(true);
+        Assertions.assertTrue(loginMemberArgumentResolver.supportsParameter(parameter));
+    }
+
+    @DisplayName("Authorization 헤더에 유효한 토큰이 있을 때 Member 객체를 반환한다")
+    @Test
+    public void returnsMemberObject_whenAuthorizationHeaderIsProvided() throws Exception {
+        // when
+        MethodParameter parameter = mock(MethodParameter.class);
+        when(parameter.hasParameterAnnotation(LoginMember.class)).thenReturn(true);
+        when(webRequest.getHeader("Authorization")).thenReturn("Bearer " + token);
+        when(jwtService.extractMemberId(any(String.class))).thenReturn(memberId);
+        when(memberService.findByMemberId(memberId)).thenReturn(member);
+
+        // then
+        Object result = loginMemberArgumentResolver.resolveArgument(parameter, mavContainer, webRequest, null);
+        assertNotNull(result);
+        assertThat(result).isEqualTo(member);
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 핸들러에 도달하기 전에 ArgumentResolver에서 토큰을 멤버 객체로 바인딩합니다.
### 성공 응답
![스크린샷 2024-10-19 오전 6 37 55](https://github.com/user-attachments/assets/9f5f8f06-e7a7-4908-b177-5f8c3b92d42c)
 
### 실패 응답 (유효하지 않은 토큰)
<img width="1005" alt="스크린샷 2024-10-19 오후 3 19 00" src="https://github.com/user-attachments/assets/7ed49016-04e4-48ae-a5c2-e0e9f16cb7e6">

### 실패 응답 (헤더 없을 때)
<img width="863" alt="스크린샷 2024-10-19 오후 3 19 13" src="https://github.com/user-attachments/assets/ea7b7183-01a4-40b5-bb35-fc057c8e5cc7">


---

## ✏️ 관련 이슈
- Resolves : #32 

---

## 🎸 기타 사항 or 추가 코멘트
- MemberService의 memberId를 가지고 멤버를 반환하는 작업을 단일 책임을 가진 클래스로 분리하면 클래스에 로직이 너무 적을 거 같아서 
MemberService를 공통 Service로 두고, 여기에는 간단한 기능을 넣으려고 하는데 어떻게 생각하시는지 궁금해요! 
- 즉 MemberService는 Member의 공통 서비스라 보면 될 거 같습니다!