### PR TITLE
Feat: (#42) 프론트 도메인에 CORS를 허용한다

### DIFF
--- a/src/main/java/spring/backend/core/configuration/WebMvcConfiguration.java
+++ b/src/main/java/spring/backend/core/configuration/WebMvcConfiguration.java
@@ -3,6 +3,7 @@ package spring.backend.core.configuration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import spring.backend.core.configuration.argumentresolver.LoginMemberArgumentResolver;
@@ -17,6 +18,15 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
     private final AuthorizationInterceptor authorizationInterceptor;
 
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000", "https://cnergy.kro.kr")
+                .allowedMethods("GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowCredentials(true)
+                .maxAge(3000);
+    }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 프론트에서 백엔드 서버 API 요청시 발생하는 CORS를 허용해주었습니다.
- local과 https 도메인을 허용해주었습니다.
- https 도메인에서 테스트할 수 없어 localhost:3000 으로 테스트 진행하였습니다.

### CORS 설정 전
![스크린샷 2024-10-21 오전 12 59 02](https://github.com/user-attachments/assets/dedff738-c957-4c2a-b146-573ef2705156)


### CORS 설정 후
![스크린샷 2024-10-21 오전 1 00 12](https://github.com/user-attachments/assets/ea4dae19-8185-4342-9816-3d1459462a29)

- `allowCredentials` : 인증과 관련된 데이터를 요청 데이터에 넣기 위해 true로 설정했습니다.
- `maxAge`: maxAge는 복잡한 요청을 보내기 전에 OPTIONS로 권한을 있는지 먼저 요청하는 PreFlight 요청을 캐싱할 수 있는 시간을 의미하는데, 기본은 1800초(30분)여서 기본 값으로 해도 괜찮을 거 같은데 3000초가 널리 쓰인다고 해서 3000초로 설정했습니다.
---

## ✏️ 관련 이슈
- Resolves : #42 

---

## 🎸 기타 사항 or 추가 코멘트