### PR TITLE
Feat: (#44) 중복 닉네임 검증 API를 구현한다.

### DIFF
--- a/src/main/java/spring/backend/member/application/ValidateNicknameService.java
+++ b/src/main/java/spring/backend/member/application/ValidateNicknameService.java
@@ -1,0 +1,35 @@
+package spring.backend.member.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import spring.backend.member.domain.repository.MemberRepository;
+import spring.backend.member.domain.value.Role;
+import spring.backend.member.exception.MemberErrorCode;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class ValidateNicknameService {
+
+    private final MemberRepository memberRepository;
+
+    public boolean validateNickname(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            log.error("[ValidateNicknameService] Nickname is empty");
+            throw MemberErrorCode.NOT_EXIST_NICKNAME.toException();
+        }
+        if (nickname.length() > 6) {
+            log.error("[ValidateNicknameService] Nickname is smaller than 6 characters");
+            throw MemberErrorCode.INVALID_NICKNAME_LENGTH.toException();
+        }
+        if (!nickname.matches("^[a-zA-Z0-9가-힣]+$")) {
+            log.error("[ValidateNicknameService] Nickname is invalid");
+            throw MemberErrorCode.INVALID_NICKNAME_FORMAT.toException();
+        }
+        if (memberRepository.existsByNicknameAndRole(nickname, Role.MEMBER)) {
+            throw MemberErrorCode.ALREADY_REGISTERED_NICKNAME.toException();
+        }
+        return true;
+    }
+}

--- a/src/main/java/spring/backend/member/domain/repository/MemberRepository.java
+++ b/src/main/java/spring/backend/member/domain/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package spring.backend.member.domain.repository;
 
 import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.value.Role;
 
 import java.util.List;
 import java.util.UUID;
@@ -11,4 +12,5 @@ public interface MemberRepository {
     Member save(Member member);
     Member findByEmail(String email);
     List<Member> findAllByEmail(String email);
+    boolean existsByNicknameAndRole(String nickname, Role role);
 }

--- a/src/main/java/spring/backend/member/exception/MemberErrorCode.java
+++ b/src/main/java/spring/backend/member/exception/MemberErrorCode.java
@@ -13,7 +13,11 @@ public enum MemberErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_CONDITION(HttpStatus.BAD_REQUEST, "요청 조건이 존재하지 않습니다."),
     ALREADY_REGISTERED_WITH_DIFFERENT_OAUTH2(HttpStatus.BAD_REQUEST, "이미 다른 소셜 로그인으로 가입된 계정입니다."),
     MEMBER_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "사용자 정보를 저장하는데 실패하였습니다."),
-    NOT_EXIST_MEMBER(HttpStatus.NOT_FOUND, "사용자가 존재하지 않습니다.");
+    NOT_EXIST_MEMBER(HttpStatus.NOT_FOUND, "사용자가 존재하지 않습니다."),
+    NOT_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임은 필수 입력값입니다."),
+    INVALID_NICKNAME_LENGTH(HttpStatus.BAD_REQUEST, "닉네임은 1자에서 6자 사이여야 합니다."),
+    INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "닉네임은 한글, 영문, 숫자 조합이어야 합니다."),
+    ALREADY_REGISTERED_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임이 이미 사용 중입니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/adapter/MemberRepositoryImpl.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/adapter/MemberRepositoryImpl.java
@@ -5,6 +5,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Repository;
 import spring.backend.member.domain.entity.Member;
 import spring.backend.member.domain.repository.MemberRepository;
+import spring.backend.member.domain.value.Role;
 import spring.backend.member.exception.MemberErrorCode;
 import spring.backend.member.infrastructure.mapper.MemberMapper;
 import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
@@ -57,5 +58,10 @@ public class MemberRepositoryImpl implements MemberRepository {
             return null;
         }
         return memberJpaEntities.stream().map(memberMapper::toDomainEntity).collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean existsByNicknameAndRole(String nickname, Role role) {
+        return memberJpaRepository.existsByNicknameAndRole(nickname, role);
     }
 }

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/repository/MemberJpaRepository.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/repository/MemberJpaRepository.java
@@ -1,6 +1,7 @@
 package spring.backend.member.infrastructure.persistence.jpa.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import spring.backend.member.domain.value.Role;
 import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
 
 import java.util.List;
@@ -11,4 +12,6 @@ public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, UUID
     MemberJpaEntity findByEmail(String email);
 
     List<MemberJpaEntity> findAllByEmail(String email);
+
+    boolean existsByNicknameAndRole(String nickname, Role role);
 }

--- a/src/main/java/spring/backend/member/presentation/ValidateNicknameController.java
+++ b/src/main/java/spring/backend/member/presentation/ValidateNicknameController.java
@@ -3,19 +3,19 @@ package spring.backend.member.presentation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.core.presentation.RestResponse;
 import spring.backend.member.application.ValidateNicknameService;
+import spring.backend.member.presentation.swagger.ValidateNicknameSwagger;
 
 @RestController
 @RequiredArgsConstructor
-public class ValidateNicknameController {
+public class ValidateNicknameController implements ValidateNicknameSwagger {
 
     private final ValidateNicknameService validateNicknameService;
 
     @GetMapping("/v1/members/check-nickname")
-    public ResponseEntity<RestResponse<Boolean>> validateNickname(@RequestParam String nickname) {
+    public ResponseEntity<RestResponse<Boolean>> validateNickname(String nickname) {
         boolean isValidNickname = validateNicknameService.validateNickname(nickname);
         return ResponseEntity.ok(new RestResponse<>(isValidNickname));
     }

--- a/src/main/java/spring/backend/member/presentation/ValidateNicknameController.java
+++ b/src/main/java/spring/backend/member/presentation/ValidateNicknameController.java
@@ -1,0 +1,22 @@
+package spring.backend.member.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.member.application.ValidateNicknameService;
+
+@RestController
+@RequiredArgsConstructor
+public class ValidateNicknameController {
+
+    private final ValidateNicknameService validateNicknameService;
+
+    @GetMapping("/v1/members/check-nickname")
+    public ResponseEntity<RestResponse<Boolean>> validateNickname(@RequestParam String nickname) {
+        boolean isValidNickname = validateNicknameService.validateNickname(nickname);
+        return ResponseEntity.ok(new RestResponse<>(isValidNickname));
+    }
+}

--- a/src/main/java/spring/backend/member/presentation/swagger/ValidateNicknameSwagger.java
+++ b/src/main/java/spring/backend/member/presentation/swagger/ValidateNicknameSwagger.java
@@ -1,0 +1,22 @@
+package spring.backend.member.presentation.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import spring.backend.core.configuration.swagger.ApiErrorCode;
+import spring.backend.core.exception.error.GlobalErrorCode;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.member.exception.MemberErrorCode;
+
+@Tag(name = "Member", description = "멤버")
+public interface ValidateNicknameSwagger {
+
+    @Operation(
+            summary = "닉네임 중복 검증 API",
+            description = "닉네임이 조건에 충족하지 않거나 중복일 경우, 에러를 발생합니다.",
+            operationId = "/v1/members/check-nickname"
+    )
+    @ApiErrorCode({GlobalErrorCode.class, MemberErrorCode.class})
+    ResponseEntity<RestResponse<Boolean>> validateNickname(@Schema(description = "요청 닉네임", example = "조각조각") String nickname);
+}

--- a/src/test/java/spring/backend/member/application/ValidateNicknameServiceTest.java
+++ b/src/test/java/spring/backend/member/application/ValidateNicknameServiceTest.java
@@ -1,0 +1,87 @@
+package spring.backend.member.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import spring.backend.core.exception.DomainException;
+import spring.backend.member.domain.repository.MemberRepository;
+import spring.backend.member.domain.value.Role;
+import spring.backend.member.exception.MemberErrorCode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ValidateNicknameServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private ValidateNicknameService validateNicknameService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    @DisplayName("닉네임이 공백일 때 예외가 발생한다.")
+    void throwExceptionWhenNicknameIsBlank() {
+        // Given
+        String nickname = " ";
+
+        // When
+        DomainException blankException = assertThrows(DomainException.class, () -> validateNicknameService.validateNickname(nickname));
+
+        // Then
+        assertEquals(MemberErrorCode.NOT_EXIST_NICKNAME.name(), blankException.getCode());
+    }
+
+    @Test
+    @DisplayName("닉네임 길이가 6자를 초과할 때 예외가 발생한다.")
+    void throwExceptionWhenNicknameLengthIsInvalid() {
+        // Given
+        String nickname = "1234567";
+
+        // When
+        DomainException longLengthException = assertThrows(DomainException.class, () -> validateNicknameService.validateNickname(nickname));
+
+        // Then
+        assertEquals(MemberErrorCode.INVALID_NICKNAME_LENGTH.name(), longLengthException.getCode());
+    }
+
+    @Test
+    @DisplayName("닉네임 형식이 유효하지 않을 때 예외가 발생한다.")
+    void throwExceptionWhenNicknameFormatIsInvalid() {
+        // Given
+        String nickname = "조각ㅈㄱ";
+
+        // When
+        DomainException formatException = assertThrows(DomainException.class, () -> validateNicknameService.validateNickname(nickname));
+
+        // Then
+        assertEquals(MemberErrorCode.INVALID_NICKNAME_FORMAT.name(), formatException.getCode());
+    }
+
+    @Test
+    @DisplayName("이미 등록된 닉네임일 경우 예외가 발생한다.")
+    void throwExceptionWhenNicknameIsAlreadyRegistered() {
+        // Given
+        String nickname = "등록된이름";
+        when(memberRepository.existsByNicknameAndRole(nickname, Role.MEMBER)).thenReturn(true);
+
+        // When
+        DomainException alreadyRegisteredException = assertThrows(DomainException.class, () -> validateNicknameService.validateNickname(nickname));
+
+        // Then
+        assertEquals(MemberErrorCode.ALREADY_REGISTERED_NICKNAME.name(), alreadyRegisteredException.getCode());
+
+        // Mock 객체 정상 동작 확인
+        verify(memberRepository).existsByNicknameAndRole(nickname, Role.MEMBER);
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 닉네임 중복 및 조건 검증을 진행하였습니다.
  - 프론트에서 검증 처리를 하는 걸로 알고 있는데 서버에서도 검증 처리가 있어야 더블체크할 수 있기 때문입니다.
  - 닉네임 중복은 Role이 MEMBER인 사용자 한정해서 검증하였습니다.
- 스웨거 문서를 작성하였습니다.
  - 컨트롤러 운영코드에 스웨거 코드의 침투를 방지하기 위해, interface로 Swagger를 만들어 구현하는 방식으로 진행하였습니다.

### 정상 응답
![스크린샷 2024-10-21 오후 5 35 49](https://github.com/user-attachments/assets/d659f79f-0eb4-481e-afe4-3b8cbcf290b5)

### 에러 응답 1
![스크린샷 2024-10-21 오후 5 36 03](https://github.com/user-attachments/assets/4433ebcd-734f-425c-83d2-c698848597ff)

### 에러 응답 2
![스크린샷 2024-10-21 오후 5 36 11](https://github.com/user-attachments/assets/7d565948-0f32-4c81-a110-c3368ee03599)

### 에러 응답 3
![스크린샷 2024-10-21 오후 5 52 17](https://github.com/user-attachments/assets/152070bf-42e2-4c44-9544-a5819cf51f02)

### 스웨거
![스크린샷 2024-10-21 오후 5 35 33](https://github.com/user-attachments/assets/181d28e0-175b-4d06-9eb7-169e39344913)



---

## ✏️ 관련 이슈
- Resolves : #44 

---

## 🎸 기타 사항 or 추가 코멘트