### PR TITLE
Feat: (#55) 활동 도메인 엔티티 및 리포지터리를 생성한다

### DIFF
--- a/src/main/java/spring/backend/activity/domain/entity/Activity.java
+++ b/src/main/java/spring/backend/activity/domain/entity/Activity.java
@@ -1,0 +1,45 @@
+package spring.backend.activity.domain.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import spring.backend.activity.domain.value.Keyword;
+import spring.backend.activity.domain.value.Type;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class Activity {
+
+    private Long id;
+
+    private UUID memberId;
+
+    private Long quickStartId;
+
+    private Integer spareTime;
+
+    private Type type;
+
+    private Set<Keyword> keywords;
+
+    private String title;
+
+    private String content;
+
+    private String location;
+
+    private Boolean finished;
+
+    private LocalDateTime finishedAt;
+
+    private Integer savedTime;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private Boolean deleted;
+}

--- a/src/main/java/spring/backend/activity/domain/entity/QuickStart.java
+++ b/src/main/java/spring/backend/activity/domain/entity/QuickStart.java
@@ -1,0 +1,32 @@
+package spring.backend.activity.domain.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import spring.backend.activity.domain.value.Type;
+
+import java.sql.Time;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class QuickStart {
+
+    private Long id;
+
+    private UUID memberId;
+
+    private String name;
+
+    private Time startTime;
+
+    private Integer spareTime;
+
+    private Type type;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private Boolean deleted;
+}

--- a/src/main/java/spring/backend/activity/domain/repository/ActivityRepository.java
+++ b/src/main/java/spring/backend/activity/domain/repository/ActivityRepository.java
@@ -1,0 +1,9 @@
+package spring.backend.activity.domain.repository;
+
+import spring.backend.activity.domain.entity.Activity;
+
+public interface ActivityRepository {
+
+    Activity findById(Long id);
+    Activity save(Activity Activity);
+}

--- a/src/main/java/spring/backend/activity/domain/repository/QuickStartRepository.java
+++ b/src/main/java/spring/backend/activity/domain/repository/QuickStartRepository.java
@@ -1,0 +1,9 @@
+package spring.backend.activity.domain.repository;
+
+import spring.backend.activity.domain.entity.QuickStart;
+
+public interface QuickStartRepository {
+
+    QuickStart findById(Long id);
+    QuickStart save(QuickStart quickStart);
+}

--- a/src/main/java/spring/backend/activity/domain/value/Keyword.java
+++ b/src/main/java/spring/backend/activity/domain/value/Keyword.java
@@ -1,0 +1,37 @@
+package spring.backend.activity.domain.value;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.*;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class Keyword {
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    private String image;
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum Category {
+        SELF_DEVELOPMENT("자기개발"),
+        HEALTH("건강"),
+        NATURE("자연"),
+        CULTURE_ART("문화/예술"),
+        ENTERTAINMENT("엔터테인먼트"),
+        RELAXATION("휴식"),
+        SOCIAL("소셜");
+
+        private final String description;
+    }
+
+    public static Keyword create(Category category, String image) {
+        return new Keyword(category, image);
+    }
+}

--- a/src/main/java/spring/backend/activity/domain/value/Type.java
+++ b/src/main/java/spring/backend/activity/domain/value/Type.java
@@ -1,0 +1,14 @@
+package spring.backend.activity.domain.value;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Type {
+    ONLINE("온라인"),
+    OFFLINE("오프라인"),
+    ONLINE_AND_OFFLINE("둘 다");
+
+    private final String description;
+}

--- a/src/main/java/spring/backend/activity/exception/ActivityErrorCode.java
+++ b/src/main/java/spring/backend/activity/exception/ActivityErrorCode.java
@@ -1,0 +1,23 @@
+package spring.backend.activity.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import spring.backend.core.exception.DomainException;
+import spring.backend.core.exception.error.BaseErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum ActivityErrorCode implements BaseErrorCode<DomainException> {
+
+    ACTIVITY_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "활동을 저장하는데 실패하였습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+        return new DomainException(httpStatus, this);
+    }
+}

--- a/src/main/java/spring/backend/activity/exception/QuickStartErrorCode.java
+++ b/src/main/java/spring/backend/activity/exception/QuickStartErrorCode.java
@@ -1,0 +1,23 @@
+package spring.backend.activity.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import spring.backend.core.exception.DomainException;
+import spring.backend.core.exception.error.BaseErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuickStartErrorCode implements BaseErrorCode<DomainException> {
+
+    QUICK_START_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "빠른 시작 정보를 저장하는데 실패하였습니다.");
+
+    private final HttpStatus httpStatus;
+
+    private final String message;
+
+    @Override
+    public DomainException toException() {
+        return new DomainException(httpStatus, this);
+    }
+}

--- a/src/main/java/spring/backend/activity/infrastructure/mapper/ActivityMapper.java
+++ b/src/main/java/spring/backend/activity/infrastructure/mapper/ActivityMapper.java
@@ -1,0 +1,51 @@
+package spring.backend.activity.infrastructure.mapper;
+
+import org.springframework.stereotype.Component;
+import spring.backend.activity.domain.entity.Activity;
+import spring.backend.activity.infrastructure.persistence.jpa.entity.ActivityJpaEntity;
+
+import java.util.Optional;
+
+@Component
+public class ActivityMapper {
+
+    public Activity toDomainEntity(ActivityJpaEntity activity) {
+        return Activity.builder()
+                .id(activity.getId())
+                .memberId(activity.getMemberId())
+                .quickStartId(activity.getQuickStartId())
+                .spareTime(activity.getSpareTime())
+                .type(activity.getType())
+                .keywords(activity.getKeywords())
+                .title(activity.getTitle())
+                .content(activity.getContent())
+                .location(activity.getLocation())
+                .finished(activity.getFinished())
+                .finishedAt(activity.getFinishedAt())
+                .savedTime(activity.getSavedTime())
+                .createdAt(activity.getCreatedAt())
+                .updatedAt(activity.getUpdatedAt())
+                .deleted(activity.getDeleted())
+                .build();
+    }
+
+    public ActivityJpaEntity toJpaEntity(Activity activity) {
+        return ActivityJpaEntity.builder()
+                .id(activity.getId())
+                .memberId(activity.getMemberId())
+                .quickStartId(activity.getQuickStartId())
+                .spareTime(activity.getSpareTime())
+                .type(activity.getType())
+                .keywords(activity.getKeywords())
+                .title(activity.getTitle())
+                .content(activity.getContent())
+                .location(activity.getLocation())
+                .finished(activity.getFinished())
+                .finishedAt(activity.getFinishedAt())
+                .savedTime(activity.getSavedTime())
+                .createdAt(activity.getCreatedAt())
+                .updatedAt(activity.getUpdatedAt())
+                .deleted(Optional.ofNullable(activity.getDeleted()).orElse(false))
+                .build();
+    }
+}

--- a/src/main/java/spring/backend/activity/infrastructure/mapper/QuickStartMapper.java
+++ b/src/main/java/spring/backend/activity/infrastructure/mapper/QuickStartMapper.java
@@ -1,0 +1,39 @@
+package spring.backend.activity.infrastructure.mapper;
+
+import org.springframework.stereotype.Component;
+import spring.backend.activity.domain.entity.QuickStart;
+import spring.backend.activity.infrastructure.persistence.jpa.entity.QuickStartJpaEntity;
+
+import java.util.Optional;
+
+@Component
+public class QuickStartMapper {
+
+    public QuickStart toDomainEntity(QuickStartJpaEntity quickStart) {
+        return QuickStart.builder()
+                .id(quickStart.getId())
+                .memberId(quickStart.getMemberId())
+                .name(quickStart.getName())
+                .startTime(quickStart.getStartTime())
+                .spareTime(quickStart.getSpareTime())
+                .type(quickStart.getType())
+                .createdAt(quickStart.getCreatedAt())
+                .updatedAt(quickStart.getUpdatedAt())
+                .deleted(quickStart.getDeleted())
+                .build();
+    }
+
+    public QuickStartJpaEntity toJpaEntity(QuickStart quickStart) {
+        return QuickStartJpaEntity.builder()
+                .id(quickStart.getId())
+                .memberId(quickStart.getMemberId())
+                .name(quickStart.getName())
+                .startTime(quickStart.getStartTime())
+                .spareTime(quickStart.getSpareTime())
+                .type(quickStart.getType())
+                .createdAt(quickStart.getCreatedAt())
+                .updatedAt(quickStart.getUpdatedAt())
+                .deleted(Optional.ofNullable(quickStart.getDeleted()).orElse(false))
+                .build();
+    }
+}

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/adapter/ActivityRepositoryImpl.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/adapter/ActivityRepositoryImpl.java
@@ -1,0 +1,41 @@
+package spring.backend.activity.infrastructure.persistence.jpa.adapter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Repository;
+import spring.backend.activity.domain.entity.Activity;
+import spring.backend.activity.domain.repository.ActivityRepository;
+import spring.backend.activity.exception.ActivityErrorCode;
+import spring.backend.activity.infrastructure.mapper.ActivityMapper;
+import spring.backend.activity.infrastructure.persistence.jpa.entity.ActivityJpaEntity;
+import spring.backend.activity.infrastructure.persistence.jpa.repository.ActivityJpaRepository;
+
+@Repository
+@RequiredArgsConstructor
+@Log4j2
+public class ActivityRepositoryImpl implements ActivityRepository {
+
+    private final ActivityMapper activityMapper;
+    private final ActivityJpaRepository activityJpaRepository;
+
+    @Override
+    public Activity findById(Long id) {
+        ActivityJpaEntity activityJpaEntity = activityJpaRepository.findById(id).orElse(null);
+        if (activityJpaEntity == null) {
+            return null;
+        }
+        return activityMapper.toDomainEntity(activityJpaEntity);
+    }
+
+    @Override
+    public Activity save(Activity activity) {
+        try {
+            ActivityJpaEntity activityJpaEntity = activityMapper.toJpaEntity(activity);
+            activityJpaRepository.save(activityJpaEntity);
+            return activityMapper.toDomainEntity(activityJpaEntity);
+        } catch (Exception e) {
+            log.error("[ActivityRepositoryImpl] Failed to save activity", e);
+            throw ActivityErrorCode.ACTIVITY_SAVE_FAILED.toException();
+        }
+    }
+}

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/adapter/QuickStartRepositoryImpl.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/adapter/QuickStartRepositoryImpl.java
@@ -1,0 +1,41 @@
+package spring.backend.activity.infrastructure.persistence.jpa.adapter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Repository;
+import spring.backend.activity.domain.entity.QuickStart;
+import spring.backend.activity.domain.repository.QuickStartRepository;
+import spring.backend.activity.exception.QuickStartErrorCode;
+import spring.backend.activity.infrastructure.mapper.QuickStartMapper;
+import spring.backend.activity.infrastructure.persistence.jpa.entity.QuickStartJpaEntity;
+import spring.backend.activity.infrastructure.persistence.jpa.repository.QuickStartJpaRepository;
+
+@Repository
+@RequiredArgsConstructor
+@Log4j2
+public class QuickStartRepositoryImpl implements QuickStartRepository {
+
+    private final QuickStartMapper quickStartMapper;
+    private final QuickStartJpaRepository quickStartJpaRepository;
+
+    @Override
+    public QuickStart findById(Long id) {
+        QuickStartJpaEntity quickStartJpaEntity = quickStartJpaRepository.findById(id).orElse(null);
+        if (quickStartJpaEntity == null) {
+            return null;
+        }
+        return quickStartMapper.toDomainEntity(quickStartJpaEntity);
+    }
+
+    @Override
+    public QuickStart save(QuickStart quickStart) {
+        try {
+            QuickStartJpaEntity quickStartJpaEntity = quickStartMapper.toJpaEntity(quickStart);
+            quickStartJpaRepository.save(quickStartJpaEntity);
+            return quickStartMapper.toDomainEntity(quickStartJpaEntity);
+        } catch (Exception e) {
+            log.error("[QuickStartRepositoryImpl] Failed to save quickStart", e);
+            throw QuickStartErrorCode.QUICK_START_SAVE_FAILED.toException();
+        }
+    }
+}

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/entity/ActivityJpaEntity.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/entity/ActivityJpaEntity.java
@@ -1,0 +1,48 @@
+package spring.backend.activity.infrastructure.persistence.jpa.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import spring.backend.activity.domain.value.Keyword;
+import spring.backend.activity.domain.value.Type;
+import spring.backend.core.infrastructure.jpa.shared.BaseLongIdEntity;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Table(name = "activity")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ActivityJpaEntity extends BaseLongIdEntity {
+
+    private UUID memberId;
+
+    private Long quickStartId;
+
+    private Integer spareTime;
+
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "activity_keyword",
+            joinColumns = @JoinColumn(name = "activity_id"))
+    private Set<Keyword> keywords;
+
+    private String title;
+
+    private String content;
+
+    private String location;
+
+    private Boolean finished;
+
+    private LocalDateTime finishedAt;
+
+    private Integer savedTime;
+}

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/entity/QuickStartJpaEntity.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/entity/QuickStartJpaEntity.java
@@ -1,0 +1,34 @@
+package spring.backend.activity.infrastructure.persistence.jpa.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import spring.backend.activity.domain.value.Type;
+import spring.backend.core.infrastructure.jpa.shared.BaseLongIdEntity;
+
+import java.sql.Time;
+import java.util.UUID;
+
+@Entity
+@Table(name = "quick_start")
+@Getter
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuickStartJpaEntity extends BaseLongIdEntity {
+
+    private UUID memberId;
+
+    private String name;
+
+    private Time startTime;
+
+    private Integer spareTime;
+
+    @Enumerated(EnumType.STRING)
+    private Type type;
+}

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/repository/ActivityJpaRepository.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/repository/ActivityJpaRepository.java
@@ -1,0 +1,7 @@
+package spring.backend.activity.infrastructure.persistence.jpa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import spring.backend.activity.infrastructure.persistence.jpa.entity.ActivityJpaEntity;
+
+public interface ActivityJpaRepository extends JpaRepository<ActivityJpaEntity, Long> {
+}

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/repository/QuickStartJpaRepository.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/repository/QuickStartJpaRepository.java
@@ -1,0 +1,7 @@
+package spring.backend.activity.infrastructure.persistence.jpa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import spring.backend.activity.infrastructure.persistence.jpa.entity.QuickStartJpaEntity;
+
+public interface QuickStartJpaRepository extends JpaRepository<QuickStartJpaEntity, Long> {
+}

--- a/src/main/java/spring/backend/core/infrastructure/jpa/shared/BaseLongIdEntity.java
+++ b/src/main/java/spring/backend/core/infrastructure/jpa/shared/BaseLongIdEntity.java
@@ -1,0 +1,34 @@
+package spring.backend.core.infrastructure.jpa.shared;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = AuditingEntityListener.class)
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BaseLongIdEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    protected Long id;
+
+    @CreatedDate
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    protected LocalDateTime updatedAt;
+
+    @Builder.Default
+    protected Boolean deleted = false;
+}

--- a/src/test/java/spring/backend/activity/domain/repository/ActivityRepositoryTest.java
+++ b/src/test/java/spring/backend/activity/domain/repository/ActivityRepositoryTest.java
@@ -1,0 +1,53 @@
+package spring.backend.activity.domain.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import spring.backend.activity.domain.entity.Activity;
+import spring.backend.activity.domain.value.Keyword;
+import spring.backend.activity.domain.value.Type;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ActivityRepositoryTest {
+
+    @Autowired
+    private ActivityRepository activityRepository;
+
+    private Activity activity;
+
+    @BeforeEach
+    void setUp() {
+        activity = Activity.builder()
+                .memberId(UUID.randomUUID())
+                .quickStartId(100L)
+                .spareTime(120)
+                .type(Type.ONLINE)
+                .keywords(Set.of(Keyword.create(Keyword.Category.SELF_DEVELOPMENT, "test.url"), Keyword.create(Keyword.Category.ENTERTAINMENT, "test1.url")))
+                .title("Test Activity")
+                .content("This is a test activity.")
+                .location("Test Location")
+                .finished(false)
+                .finishedAt(null)
+                .savedTime(30)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .deleted(false)
+                .build();
+    }
+
+    @Test
+    void testSaveAndFindActivity() {
+        Activity savedActivity = activityRepository.save(activity);
+        Activity foundActivity = activityRepository.findById(savedActivity.getId());
+
+        assertThat(foundActivity).isNotNull();
+        assertThat(foundActivity.getKeywords()).isEqualTo(activity.getKeywords());
+    }
+}

--- a/src/test/java/spring/backend/activity/domain/repository/QuickStartRepositoryTest.java
+++ b/src/test/java/spring/backend/activity/domain/repository/QuickStartRepositoryTest.java
@@ -1,0 +1,46 @@
+package spring.backend.activity.domain.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import spring.backend.activity.domain.entity.QuickStart;
+import spring.backend.activity.domain.value.Type;
+
+import java.sql.Time;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class QuickStartRepositoryTest {
+
+    @Autowired
+    private QuickStartRepository quickStartRepository;
+
+    private QuickStart quickStart;
+
+    @BeforeEach
+    void setUp() {
+        quickStart = QuickStart.builder()
+                .memberId(UUID.randomUUID())
+                .name("Test QuickStart")
+                .startTime(Time.valueOf("01:02:03"))
+                .spareTime(60)
+                .type(Type.ONLINE)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .deleted(false)
+                .build();
+    }
+
+    @Test
+    void testSaveAndFindQuickStart() {
+        QuickStart savedQuickStart = quickStartRepository.save(quickStart);
+        QuickStart foundQuickStart = quickStartRepository.findById(savedQuickStart.getId());
+
+        assertThat(foundQuickStart).isNotNull();
+        assertThat(foundQuickStart.getStartTime()).isEqualTo(quickStart.getStartTime());
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 활동 도메인에서 필요한 Activity, QuickStart의 기본 토대를 구축하였습니다.
  - 도메인 계층의 엔티티, 밸류타입, 리포지터리를 생성하였습니다.
  - 인프라 계층의 매퍼, 어댑터, Jpa리포지터리를 생성하였습니다.

### Activity 저장 및 조회 결과
![스크린샷 2024-10-28 오전 6 52 57](https://github.com/user-attachments/assets/a9be9a46-bbbb-4759-a94e-aac41ff247d2)

### QuickStart 저장 및 조회 결과
![스크린샷 2024-10-28 오전 7 04 42](https://github.com/user-attachments/assets/de7bb10b-827d-4cae-82fc-02c293e5eef6)

---

## ✏️ 관련 이슈
- Resolves : #55 

---

## 🎸 기타 사항 or 추가 코멘트
- 원래 논의 결과, 빠른 시작 도메인을 activity_quickstart 로 정의했는데 activity에서 빠른 시작의 id를 가지기 때문에 quick_start로 변경했는데 괜찮을까요??
- Keyword 밸류에서 create는 테스트를 위해 만들었는데 추후 사용해도 될 거 같고 만약 사용 안하면 제거해야합니다.
- 밸류는 불변 객체로 관리해야하기 때문에 @AllArgsConstructor을 PRIVATE으로 제한하였습니다. 추후 밸류를 변경할 때는 객체 값을 변경하는 것이 아닌 다른 객체를 생성해야합니다!!!