### PR TITLE
Feat: (#58) 빠른 시작 생성 API를 구현한다

### DIFF
--- a/src/main/java/spring/backend/activity/application/CreateQuickStartService.java
+++ b/src/main/java/spring/backend/activity/application/CreateQuickStartService.java
@@ -1,0 +1,42 @@
+package spring.backend.activity.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import spring.backend.activity.domain.entity.QuickStart;
+import spring.backend.activity.domain.repository.QuickStartRepository;
+import spring.backend.activity.dto.request.QuickStartRequest;
+import spring.backend.activity.exception.QuickStartErrorCode;
+import spring.backend.member.domain.entity.Member;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+@Transactional
+public class CreateQuickStartService {
+
+    private final QuickStartRepository quickStartRepository;
+
+    public Long createQuickStart(Member member, QuickStartRequest request) {
+        validateRequest(request);
+        validateMember(member);
+        QuickStart quickStart = QuickStart.create(member.getId(), request.name(), request.startTime(), request.spareTime(), request.type());
+        QuickStart savedQuickStart = quickStartRepository.save(quickStart);
+        return savedQuickStart.getId();
+    }
+
+    private void validateRequest(QuickStartRequest request) {
+        if (request == null) {
+            log.error("[CreateQuickStartService] Invalid request.");
+            throw QuickStartErrorCode.NOT_EXIST_QUICK_START_CONDITION.toException();
+        }
+    }
+
+    private void validateMember(Member member) {
+        if (!member.isMember()) {
+            log.error("[CreateQuickStartService] Client is not a member.");
+            throw QuickStartErrorCode.NOT_A_MEMBER.toException();
+        }
+    }
+}

--- a/src/main/java/spring/backend/activity/application/ReadQuickStartsService.java
+++ b/src/main/java/spring/backend/activity/application/ReadQuickStartsService.java
@@ -1,0 +1,36 @@
+package spring.backend.activity.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import spring.backend.activity.dto.response.QuickStartResponse;
+import spring.backend.activity.dto.response.QuickStartsResponse;
+import spring.backend.activity.exception.QuickStartErrorCode;
+import spring.backend.activity.query.dao.QuickStartDao;
+import spring.backend.member.domain.entity.Member;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+@Transactional(readOnly = true)
+public class ReadQuickStartsService {
+
+    private final QuickStartDao quickStartDao;
+
+    public QuickStartsResponse readQuickStarts(Member member) {
+        validateMember(member);
+        List<QuickStartResponse> quickStartResponses = quickStartDao.findByMemberId(member.getId(), Sort.by("createdAt").descending());
+        return new QuickStartsResponse(quickStartResponses);
+    }
+
+    private void validateMember(Member member) {
+        if (!member.isMember()) {
+            log.error("[ReadQuickStartsService] Client is not a member.");
+            throw QuickStartErrorCode.NOT_A_MEMBER.toException();
+        }
+    }
+}

--- a/src/main/java/spring/backend/activity/application/UpdateQuickStartService.java
+++ b/src/main/java/spring/backend/activity/application/UpdateQuickStartService.java
@@ -1,0 +1,64 @@
+package spring.backend.activity.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import spring.backend.activity.domain.entity.QuickStart;
+import spring.backend.activity.domain.repository.QuickStartRepository;
+import spring.backend.activity.dto.request.QuickStartRequest;
+import spring.backend.activity.exception.QuickStartErrorCode;
+import spring.backend.member.domain.entity.Member;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+@Transactional
+public class UpdateQuickStartService {
+
+    private final QuickStartRepository quickStartRepository;
+
+    public void updateQuickStart(Member member, QuickStartRequest request, Long quickStartId) {
+        QuickStart quickStart = quickStartRepository.findById(quickStartId);
+        validateUpdateRequest(member, request, quickStart);
+        quickStart.update(request.name(), request.startTime(), request.spareTime(), request.type());
+        quickStartRepository.save(quickStart);
+    }
+
+    private void validateUpdateRequest(Member member, QuickStartRequest request, QuickStart quickStart) {
+        validateQuickStartExistence(quickStart);
+        validateRequest(request);
+        validateMember(member);
+        validateMemberId(member.getId(), quickStart.getMemberId());
+    }
+
+    private void validateQuickStartExistence(QuickStart quickStart) {
+        if (quickStart == null) {
+            log.error("[validateQuickStartExistence] QuickStart does not exist.");
+            throw QuickStartErrorCode.NOT_EXIST_QUICK_START.toException();
+        }
+    }
+
+    private void validateRequest(QuickStartRequest request) {
+        if (request == null) {
+            log.error("[validateRequest] Request is null.");
+            throw QuickStartErrorCode.NOT_EXIST_QUICK_START_CONDITION.toException();
+        }
+    }
+
+    private void validateMember(Member member) {
+        if (!member.isMember()) {
+            log.error("[validateMember] Unauthorized member.");
+            throw QuickStartErrorCode.NOT_A_MEMBER.toException();
+        }
+    }
+
+    private void validateMemberId(UUID memberId, UUID quickStartMemberId) {
+        if (!memberId.equals(quickStartMemberId)) {
+            log.error("[validateMemberId] Member id mismatch");
+            throw QuickStartErrorCode.MEMBER_ID_MISMATCH.toException();
+        }
+    }
+}

--- a/src/main/java/spring/backend/activity/domain/entity/QuickStart.java
+++ b/src/main/java/spring/backend/activity/domain/entity/QuickStart.java
@@ -29,4 +29,14 @@ public class QuickStart {
     private LocalDateTime updatedAt;
 
     private Boolean deleted;
+
+    public static QuickStart create(UUID memberId, String name, Time startTime, Integer spareTime, Type type) {
+        return QuickStart.builder()
+                .memberId(memberId)
+                .name(name)
+                .startTime(startTime)
+                .spareTime(spareTime)
+                .type(type)
+                .build();
+    }
 }

--- a/src/main/java/spring/backend/activity/domain/entity/QuickStart.java
+++ b/src/main/java/spring/backend/activity/domain/entity/QuickStart.java
@@ -39,4 +39,11 @@ public class QuickStart {
                 .type(type)
                 .build();
     }
+
+    public void update(String name, Time startTime, Integer spareTime, Type type) {
+        this.name = name;
+        this.startTime = startTime;
+        this.spareTime = spareTime;
+        this.type = type;
+    }
 }

--- a/src/main/java/spring/backend/activity/dto/request/QuickStartRequest.java
+++ b/src/main/java/spring/backend/activity/dto/request/QuickStartRequest.java
@@ -1,5 +1,6 @@
 package spring.backend.activity.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -12,17 +13,21 @@ public record QuickStartRequest(
 
         @NotNull(message = "이름은 필수 입력 항목입니다.")
         @Pattern(regexp = "^[a-zA-Z0-9가-힣]{1,10}$", message = "이름은 한글, 영문, 숫자만 입력 가능하며 최대 10자까지 입력 가능합니다.")
+        @Schema(description = "빠른 시작 이름", example = "등교")
         String name,
 
         @NotNull(message = "시작 시간은 필수 입력 항목입니다.")
+        @Schema(description = "시작 시간", example = "12:30:00")
         Time startTime,
 
         @NotNull(message = "자투리 시간은 필수 입력 항목입니다.")
         @Min(value = 10, message = "자투리 시간은 최소 10이어야 합니다.")
         @Max(value = 300, message = "자투리 시간은 최대 300이어야 합니다.")
+        @Schema(description = "자투리 시간", example = "300")
         Integer spareTime,
 
         @NotNull(message = "활동 유형은 필수 입력 항목입니다.")
+        @Schema(description = "활동 유형 (ONLINE, OFFLINE, ONLINE_AND_OFFLINE)", example = "ONLINE")
         Type type
 ) {
 }

--- a/src/main/java/spring/backend/activity/dto/request/QuickStartRequest.java
+++ b/src/main/java/spring/backend/activity/dto/request/QuickStartRequest.java
@@ -1,10 +1,7 @@
 package spring.backend.activity.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.*;
 import spring.backend.activity.domain.value.Type;
 
 import java.sql.Time;
@@ -12,7 +9,8 @@ import java.sql.Time;
 public record QuickStartRequest(
 
         @NotNull(message = "이름은 필수 입력 항목입니다.")
-        @Pattern(regexp = "^[a-zA-Z0-9가-힣]{1,10}$", message = "이름은 한글, 영문, 숫자만 입력 가능하며 최대 10자까지 입력 가능합니다.")
+        @Pattern(regexp = "^(?!\\s)([a-zA-Z0-9가-힣]+(\\s[a-zA-Z0-9가-힣]+)*)?$", message = "이름은 한글, 영문, 숫자 및 공백만 입력 가능하며, 공백으로 시작하거나 끝날 수 없고, 연속된 공백이 없어야 합니다.")
+        @Size(max = 10, message = "최대 10자까지 입력 가능합니다.")
         @Schema(description = "빠른 시작 이름", example = "등교")
         String name,
 

--- a/src/main/java/spring/backend/activity/dto/request/QuickStartRequest.java
+++ b/src/main/java/spring/backend/activity/dto/request/QuickStartRequest.java
@@ -1,0 +1,28 @@
+package spring.backend.activity.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import spring.backend.activity.domain.value.Type;
+
+import java.sql.Time;
+
+public record QuickStartRequest(
+
+        @NotNull(message = "이름은 필수 입력 항목입니다.")
+        @Pattern(regexp = "^[a-zA-Z0-9가-힣]{1,10}$", message = "이름은 한글, 영문, 숫자만 입력 가능하며 최대 10자까지 입력 가능합니다.")
+        String name,
+
+        @NotNull(message = "시작 시간은 필수 입력 항목입니다.")
+        Time startTime,
+
+        @NotNull(message = "자투리 시간은 필수 입력 항목입니다.")
+        @Min(value = 10, message = "자투리 시간은 최소 10이어야 합니다.")
+        @Max(value = 300, message = "자투리 시간은 최대 300이어야 합니다.")
+        Integer spareTime,
+
+        @NotNull(message = "활동 유형은 필수 입력 항목입니다.")
+        Type type
+) {
+}

--- a/src/main/java/spring/backend/activity/dto/response/QuickStartResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/QuickStartResponse.java
@@ -1,14 +1,25 @@
 package spring.backend.activity.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import spring.backend.activity.domain.value.Type;
 
 import java.sql.Time;
 
 public record QuickStartResponse(
+
+        @Schema(description = "빠른 시작 ID", example = "1")
         Long id,
+
+        @Schema(description = "빠른 시작 이름", example = "등교")
         String name,
+
+        @Schema(description = "시작 시간", example = "12:30:00")
         Time startTime,
+
+        @Schema(description = "자투리 시간", example = "300")
         Integer spareTime,
+
+        @Schema(description = "활동 유형 (ONLINE, OFFLINE, ONLINE_AND_OFFLINE)", example = "ONLINE")
         Type type
 ) {
 }

--- a/src/main/java/spring/backend/activity/dto/response/QuickStartResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/QuickStartResponse.java
@@ -1,0 +1,14 @@
+package spring.backend.activity.dto.response;
+
+import spring.backend.activity.domain.value.Type;
+
+import java.sql.Time;
+
+public record QuickStartResponse(
+        Long id,
+        String name,
+        Time startTime,
+        Integer spareTime,
+        Type type
+) {
+}

--- a/src/main/java/spring/backend/activity/dto/response/QuickStartsResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/QuickStartsResponse.java
@@ -1,8 +1,12 @@
 package spring.backend.activity.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record QuickStartsResponse(
+
+        @Schema(description = "빠른 시작 리스트")
         List<QuickStartResponse> quickStartResponses
 ) {
 }

--- a/src/main/java/spring/backend/activity/dto/response/QuickStartsResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/QuickStartsResponse.java
@@ -1,0 +1,8 @@
+package spring.backend.activity.dto.response;
+
+import java.util.List;
+
+public record QuickStartsResponse(
+        List<QuickStartResponse> quickStartResponses
+) {
+}

--- a/src/main/java/spring/backend/activity/exception/QuickStartErrorCode.java
+++ b/src/main/java/spring/backend/activity/exception/QuickStartErrorCode.java
@@ -10,7 +10,9 @@ import spring.backend.core.exception.error.BaseErrorCode;
 @RequiredArgsConstructor
 public enum QuickStartErrorCode implements BaseErrorCode<DomainException> {
 
-    QUICK_START_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "빠른 시작 정보를 저장하는데 실패하였습니다.");
+    QUICK_START_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "빠른 시작 정보를 저장하는데 실패하였습니다."),
+    NOT_EXIST_QUICK_START_CONDITION(HttpStatus.BAD_REQUEST, "빠른 시작 요청 조건이 유효하지 않습니다."),
+    NOT_A_MEMBER(HttpStatus.FORBIDDEN, "사용자가 멤버 사용자가 아닙니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/spring/backend/activity/exception/QuickStartErrorCode.java
+++ b/src/main/java/spring/backend/activity/exception/QuickStartErrorCode.java
@@ -12,7 +12,9 @@ public enum QuickStartErrorCode implements BaseErrorCode<DomainException> {
 
     QUICK_START_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "빠른 시작 정보를 저장하는데 실패하였습니다."),
     NOT_EXIST_QUICK_START_CONDITION(HttpStatus.BAD_REQUEST, "빠른 시작 요청 조건이 유효하지 않습니다."),
-    NOT_A_MEMBER(HttpStatus.FORBIDDEN, "사용자가 멤버 사용자가 아닙니다.");
+    NOT_A_MEMBER(HttpStatus.FORBIDDEN, "사용자가 멤버 사용자가 아닙니다."),
+    NOT_EXIST_QUICK_START(HttpStatus.BAD_REQUEST, "빠른 시작이 존재하지 않습니다."),
+    MEMBER_ID_MISMATCH(HttpStatus.FORBIDDEN, "빠른 시작과 멤버 ID가 일치하지 않습니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/dao/QuickStartJpaDao.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/dao/QuickStartJpaDao.java
@@ -1,0 +1,28 @@
+package spring.backend.activity.infrastructure.persistence.jpa.dao;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import spring.backend.activity.dto.response.QuickStartResponse;
+import spring.backend.activity.infrastructure.persistence.jpa.entity.QuickStartJpaEntity;
+import spring.backend.activity.query.dao.QuickStartDao;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface QuickStartJpaDao extends JpaRepository<QuickStartJpaEntity, Long>, QuickStartDao {
+
+    @Override
+    @Query("""
+        select new spring.backend.activity.dto.response.QuickStartResponse(
+            q.id,
+            q.name,
+            q.startTime,
+            q.spareTime,
+            q.type
+        )
+        from QuickStartJpaEntity q
+        where q.memberId = :memberId
+    """)
+    List<QuickStartResponse> findByMemberId(UUID memberId, Sort sort);
+}

--- a/src/main/java/spring/backend/activity/presentation/CreateQuickStartController.java
+++ b/src/main/java/spring/backend/activity/presentation/CreateQuickStartController.java
@@ -1,0 +1,29 @@
+package spring.backend.activity.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import spring.backend.activity.application.CreateQuickStartService;
+import spring.backend.activity.dto.request.QuickStartRequest;
+import spring.backend.activity.presentation.swagger.CreateQuickStartSwagger;
+import spring.backend.core.configuration.argumentresolver.LoginMember;
+import spring.backend.core.configuration.interceptor.Authorization;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.member.domain.entity.Member;
+
+@RestController
+@RequiredArgsConstructor
+public class CreateQuickStartController implements CreateQuickStartSwagger {
+
+    private final CreateQuickStartService createQuickStartService;
+
+    @Authorization
+    @PostMapping("/v1/quick-starts")
+    public ResponseEntity<RestResponse<Long>> createQuickStart(@LoginMember Member member, @Valid @RequestBody QuickStartRequest request) {
+        Long memberId = createQuickStartService.createQuickStart(member, request);
+        return ResponseEntity.ok(new RestResponse<>(memberId));
+    }
+}

--- a/src/main/java/spring/backend/activity/presentation/ReadQuickStartsController.java
+++ b/src/main/java/spring/backend/activity/presentation/ReadQuickStartsController.java
@@ -1,0 +1,25 @@
+package spring.backend.activity.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import spring.backend.activity.application.ReadQuickStartsService;
+import spring.backend.activity.dto.response.QuickStartsResponse;
+import spring.backend.core.configuration.argumentresolver.LoginMember;
+import spring.backend.core.configuration.interceptor.Authorization;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.member.domain.entity.Member;
+
+@RestController
+@RequiredArgsConstructor
+public class ReadQuickStartsController {
+
+    private final ReadQuickStartsService readQuickStartsService;
+
+    @Authorization
+    @GetMapping("/v1/quick-starts")
+    public ResponseEntity<RestResponse<QuickStartsResponse>> readQuickStarts(@LoginMember Member member) {
+        return ResponseEntity.ok(new RestResponse<>(readQuickStartsService.readQuickStarts(member)));
+    }
+}

--- a/src/main/java/spring/backend/activity/presentation/ReadQuickStartsController.java
+++ b/src/main/java/spring/backend/activity/presentation/ReadQuickStartsController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.activity.application.ReadQuickStartsService;
 import spring.backend.activity.dto.response.QuickStartsResponse;
+import spring.backend.activity.presentation.swagger.ReadQuickStartsSwagger;
 import spring.backend.core.configuration.argumentresolver.LoginMember;
 import spring.backend.core.configuration.interceptor.Authorization;
 import spring.backend.core.presentation.RestResponse;
@@ -13,7 +14,7 @@ import spring.backend.member.domain.entity.Member;
 
 @RestController
 @RequiredArgsConstructor
-public class ReadQuickStartsController {
+public class ReadQuickStartsController implements ReadQuickStartsSwagger {
 
     private final ReadQuickStartsService readQuickStartsService;
 

--- a/src/main/java/spring/backend/activity/presentation/UpdateQuickStartController.java
+++ b/src/main/java/spring/backend/activity/presentation/UpdateQuickStartController.java
@@ -1,0 +1,28 @@
+package spring.backend.activity.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import spring.backend.activity.application.UpdateQuickStartService;
+import spring.backend.activity.dto.request.QuickStartRequest;
+import spring.backend.core.configuration.argumentresolver.LoginMember;
+import spring.backend.core.configuration.interceptor.Authorization;
+import spring.backend.member.domain.entity.Member;
+
+@RestController
+@RequiredArgsConstructor
+public class UpdateQuickStartController {
+
+    private final UpdateQuickStartService updateQuickStartService;
+
+    @Authorization
+    @PatchMapping("/v1/quick-starts/{quickStartId}")
+    public ResponseEntity<Void> updateQuickStart(@LoginMember Member member, @Valid @RequestBody QuickStartRequest request, @PathVariable Long quickStartId) {
+        updateQuickStartService.updateQuickStart(member, request, quickStartId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/spring/backend/activity/presentation/UpdateQuickStartController.java
+++ b/src/main/java/spring/backend/activity/presentation/UpdateQuickStartController.java
@@ -9,13 +9,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.activity.application.UpdateQuickStartService;
 import spring.backend.activity.dto.request.QuickStartRequest;
+import spring.backend.activity.presentation.swagger.UpdateQuickStartSwagger;
 import spring.backend.core.configuration.argumentresolver.LoginMember;
 import spring.backend.core.configuration.interceptor.Authorization;
 import spring.backend.member.domain.entity.Member;
 
 @RestController
 @RequiredArgsConstructor
-public class UpdateQuickStartController {
+public class UpdateQuickStartController implements UpdateQuickStartSwagger {
 
     private final UpdateQuickStartService updateQuickStartService;
 

--- a/src/main/java/spring/backend/activity/presentation/swagger/CreateQuickStartSwagger.java
+++ b/src/main/java/spring/backend/activity/presentation/swagger/CreateQuickStartSwagger.java
@@ -1,0 +1,24 @@
+package spring.backend.activity.presentation.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import spring.backend.activity.dto.request.QuickStartRequest;
+import spring.backend.activity.exception.QuickStartErrorCode;
+import spring.backend.core.configuration.swagger.ApiErrorCode;
+import spring.backend.core.exception.error.GlobalErrorCode;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.member.domain.entity.Member;
+
+@Tag(name = "QuickStart", description = "빠른 시작")
+public interface CreateQuickStartSwagger {
+
+    @Operation(
+            summary = "빠른 시작 생성 API",
+            description = "빠른 시작을 생성합니다.",
+            operationId = "/v1/quick-starts"
+    )
+    @ApiErrorCode({GlobalErrorCode.class, QuickStartErrorCode.class})
+    ResponseEntity<RestResponse<Long>> createQuickStart(@Parameter(hidden = true) Member member, QuickStartRequest request);
+}

--- a/src/main/java/spring/backend/activity/presentation/swagger/ReadQuickStartsSwagger.java
+++ b/src/main/java/spring/backend/activity/presentation/swagger/ReadQuickStartsSwagger.java
@@ -1,0 +1,24 @@
+package spring.backend.activity.presentation.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import spring.backend.activity.dto.response.QuickStartsResponse;
+import spring.backend.activity.exception.QuickStartErrorCode;
+import spring.backend.core.configuration.swagger.ApiErrorCode;
+import spring.backend.core.exception.error.GlobalErrorCode;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.member.domain.entity.Member;
+
+@Tag(name = "QuickStart", description = "빠른 시작")
+public interface ReadQuickStartsSwagger {
+
+    @Operation(
+            summary = "빠른 시작 리스트 조회 API",
+            description = "사용자가 생성한 빠른 시작 리스트를 반환합니다.",
+            operationId = "/v1/quick-starts"
+    )
+    @ApiErrorCode({GlobalErrorCode.class, QuickStartErrorCode.class})
+    ResponseEntity<RestResponse<QuickStartsResponse>> readQuickStarts(@Parameter(hidden = true) Member member);
+}

--- a/src/main/java/spring/backend/activity/presentation/swagger/UpdateQuickStartSwagger.java
+++ b/src/main/java/spring/backend/activity/presentation/swagger/UpdateQuickStartSwagger.java
@@ -1,0 +1,23 @@
+package spring.backend.activity.presentation.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import spring.backend.activity.dto.request.QuickStartRequest;
+import spring.backend.activity.exception.QuickStartErrorCode;
+import spring.backend.core.configuration.swagger.ApiErrorCode;
+import spring.backend.core.exception.error.GlobalErrorCode;
+import spring.backend.member.domain.entity.Member;
+
+@Tag(name = "QuickStart", description = "빠른 시작")
+public interface UpdateQuickStartSwagger {
+
+    @Operation(
+            summary = "빠른 시작 수정 API",
+            description = "빠른 시작 ID를 통해 빠른 시작을 수정합니다.",
+            operationId = "/v1/quick-starts/{quickStartId}"
+    )
+    @ApiErrorCode({GlobalErrorCode.class, QuickStartErrorCode.class})
+    ResponseEntity<Void> updateQuickStart(@Parameter(hidden = true) Member member, QuickStartRequest request, Long quickStartId);
+}

--- a/src/main/java/spring/backend/activity/query/dao/QuickStartDao.java
+++ b/src/main/java/spring/backend/activity/query/dao/QuickStartDao.java
@@ -1,0 +1,12 @@
+package spring.backend.activity.query.dao;
+
+import org.springframework.data.domain.Sort;
+import spring.backend.activity.dto.response.QuickStartResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface QuickStartDao {
+
+    List<QuickStartResponse> findByMemberId(UUID memberId, Sort sort);
+}

--- a/src/test/java/spring/backend/activity/application/CreateQuickStartServiceTest.java
+++ b/src/test/java/spring/backend/activity/application/CreateQuickStartServiceTest.java
@@ -1,0 +1,88 @@
+package spring.backend.activity.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import spring.backend.activity.domain.entity.QuickStart;
+import spring.backend.activity.domain.repository.QuickStartRepository;
+import spring.backend.activity.domain.value.Type;
+import spring.backend.activity.dto.request.QuickStartRequest;
+import spring.backend.activity.exception.QuickStartErrorCode;
+import spring.backend.core.exception.DomainException;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.value.Role;
+
+import java.sql.Time;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateQuickStartServiceTest {
+
+    @InjectMocks
+    private CreateQuickStartService createQuickStartService;
+
+    @Mock
+    private QuickStartRepository quickStartRepository;
+
+    private Member member;
+    private Member guest;
+    private QuickStartRequest request;
+
+    @BeforeEach
+    public void setUp() {
+        member = Member.builder()
+                .role(Role.MEMBER)
+                .build();
+        guest = Member.builder()
+                .role(Role.GUEST)
+                .build();
+        request = new QuickStartRequest(
+                "등교",
+                Time.valueOf("12:30:00"),
+                300,
+                Type.ONLINE
+        );
+    }
+
+    @DisplayName("요청이 null인 경우 예외가 발생한다")
+    @Test
+    public void createQuickStart_NullRequest_ThrowsException() {
+        // when
+        DomainException ex = assertThrows(DomainException.class, () -> createQuickStartService.createQuickStart(member, null));
+
+        // then
+        assertEquals(QuickStartErrorCode.NOT_EXIST_QUICK_START_CONDITION.getMessage(), ex.getMessage());
+    }
+
+    @DisplayName("비회원이 요청하는 경우 예외가 발생한다")
+    @Test
+    public void createQuickStart_NonMember_ThrowsException() {
+        // when
+        DomainException ex = assertThrows(DomainException.class, () -> createQuickStartService.createQuickStart(guest, request));
+
+        // then
+        assertEquals(QuickStartErrorCode.NOT_A_MEMBER.getMessage(), ex.getMessage());
+    }
+
+    @DisplayName("유효한 빠른 시작 요청인 경우 저장된 ID를 반환한다")
+    @Test
+    public void createQuickStart_ValidRequest_ReturnsSavedQuickStartId() {
+        QuickStart quickStart = QuickStart.create(member.getId(), request.name(), request.startTime(), request.spareTime(), request.type());
+        when(quickStartRepository.save(any(QuickStart.class))).thenReturn(quickStart);
+
+        // when
+        Long savedQuickStartId = createQuickStartService.createQuickStart(member, request);
+
+        // then
+        assertEquals(quickStart.getId(), savedQuickStartId);
+        verify(quickStartRepository).save(any(QuickStart.class));
+    }
+}

--- a/src/test/java/spring/backend/activity/dto/request/QuickStartRequestTest.java
+++ b/src/test/java/spring/backend/activity/dto/request/QuickStartRequestTest.java
@@ -1,0 +1,75 @@
+package spring.backend.activity.dto.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import spring.backend.activity.domain.value.Type;
+
+import java.sql.Time;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class QuickStartRequestTest {
+
+    private final Validator validator;
+
+    public QuickStartRequestTest() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            this.validator = factory.getValidator();
+        }
+    }
+
+    @Nested
+    @DisplayName("name 필드 검증 테스트")
+    class NameValidationTests {
+
+        @Test
+        @DisplayName("null 값일 경우 에러가 발생한다.")
+        void whenNameIsNull_thenValidationFails() {
+            QuickStartRequest request = new QuickStartRequest(null, Time.valueOf("12:30:00"), 300, Type.OFFLINE);
+            Set<ConstraintViolation<QuickStartRequest>> violations = validator.validate(request);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(violation -> violation.getMessage().contains("이름은 필수 입력 항목입니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("올바른 형식의 이름일 경우 성공한다.")
+        @ValueSource(strings = {"등교", "이름테스트", "John Doe", "사용자1"})
+        void whenNameIsValid_thenValidationSucceeds(String name) {
+            QuickStartRequest request = new QuickStartRequest(name, Time.valueOf("12:30:00"), 300, Type.OFFLINE);
+            Set<ConstraintViolation<QuickStartRequest>> violations = validator.validate(request);
+
+            assertThat(violations).isEmpty();
+        }
+
+        @ParameterizedTest
+        @DisplayName("형식에 맞지 않는 이름일 경우 에러가 발생한다.")
+        @ValueSource(strings = {" 이름", "이름 ", "이름@이름", "공백  공백"})
+        void whenNameIsInvalid_thenValidationFails(String name) {
+            QuickStartRequest request = new QuickStartRequest(name, Time.valueOf("12:30:00"), 300, Type.OFFLINE);
+            Set<ConstraintViolation<QuickStartRequest>> violations = validator.validate(request);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(violation -> violation.getMessage().contains("이름은 한글, 영문, 숫자 및 공백만 입력 가능하며"));
+        }
+
+        @Test
+        @DisplayName("10자를 초과하는 경우 에러가 발생한다.")
+        void whenNameExceedsMaxLength_thenValidationFails() {
+            String name = "매우몹시너무긴이름longname";
+            QuickStartRequest request = new QuickStartRequest(name, Time.valueOf("12:30:00"), 300, Type.OFFLINE);
+            Set<ConstraintViolation<QuickStartRequest>> violations = validator.validate(request);
+
+            assertThat(violations).isNotEmpty();
+            assertThat(violations).anyMatch(violation -> violation.getMessage().contains("최대 10자까지 입력 가능합니다."));
+        }
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 빠른 시작 생성 API를 구현하였습니다.

### 성공응답
![스크린샷 2024-10-29 오후 11 47 22](https://github.com/user-attachments/assets/376f7774-8a81-4ed1-9e1e-542c355d663f)

### 실패응답 (닉네임 10글자 넘을 경우)
![스크린샷 2024-10-29 오후 11 48 24](https://github.com/user-attachments/assets/a08775e7-2b3c-4e8c-8881-adc7f739babb)

### 실패응답 (숫자 10미만, 300초과일 경우)
![스크린샷 2024-10-29 오후 11 48 43](https://github.com/user-attachments/assets/111148ad-0df0-482c-9428-689fe3c8b9e5)


---

## ✏️ 관련 이슈
- Resolves : #58 

---

## 🎸 기타 사항 or 추가 코멘트
- 아직 완료된 작업은 아닙니다. 기획, 프론트와 요청 값 관련해서 논의해야해서 답변을 기다리고 있습니다.
  - name : 띄어쓰기가 가능한지, 띄어쓰기 포함 10자인지에 대해 답변 대기중입니다. -> 앞, 뒤 공백, 연속 공백 불가 및 공백 포함 10자로 결정
  - startTime : 오전, 오후를 프론트에서 변환할지, 백에서 변환할지에 대해 답변 대기중입니다. -> 프론트에서 변환 처리해서 보내주기로 결정