### PR TITLE
Feat: (#60) 빠른 시작 리스트 조회 API를 구현한다

### DIFF
--- a/src/main/java/spring/backend/activity/application/ReadQuickStartsService.java
+++ b/src/main/java/spring/backend/activity/application/ReadQuickStartsService.java
@@ -1,0 +1,36 @@
+package spring.backend.activity.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import spring.backend.activity.dto.response.QuickStartResponse;
+import spring.backend.activity.dto.response.QuickStartsResponse;
+import spring.backend.activity.exception.QuickStartErrorCode;
+import spring.backend.activity.query.dao.QuickStartDao;
+import spring.backend.member.domain.entity.Member;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+@Transactional(readOnly = true)
+public class ReadQuickStartsService {
+
+    private final QuickStartDao quickStartDao;
+
+    public QuickStartsResponse readQuickStarts(Member member) {
+        validateMember(member);
+        List<QuickStartResponse> quickStartResponses = quickStartDao.findByMemberId(member.getId(), Sort.by("createdAt").descending());
+        return new QuickStartsResponse(quickStartResponses);
+    }
+
+    private void validateMember(Member member) {
+        if (!member.isMember()) {
+            log.error("[ReadQuickStartsService] Client is not a member.");
+            throw QuickStartErrorCode.NOT_A_MEMBER.toException();
+        }
+    }
+}

--- a/src/main/java/spring/backend/activity/dto/response/QuickStartResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/QuickStartResponse.java
@@ -1,14 +1,25 @@
 package spring.backend.activity.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import spring.backend.activity.domain.value.Type;
 
 import java.sql.Time;
 
 public record QuickStartResponse(
+
+        @Schema(description = "빠른 시작 ID", example = "1")
         Long id,
+
+        @Schema(description = "빠른 시작 이름", example = "등교")
         String name,
+
+        @Schema(description = "시작 시간", example = "12:30:00")
         Time startTime,
+
+        @Schema(description = "자투리 시간", example = "300")
         Integer spareTime,
+
+        @Schema(description = "활동 유형 (ONLINE, OFFLINE, ONLINE_AND_OFFLINE)", example = "ONLINE")
         Type type
 ) {
 }

--- a/src/main/java/spring/backend/activity/dto/response/QuickStartResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/QuickStartResponse.java
@@ -1,0 +1,14 @@
+package spring.backend.activity.dto.response;
+
+import spring.backend.activity.domain.value.Type;
+
+import java.sql.Time;
+
+public record QuickStartResponse(
+        Long id,
+        String name,
+        Time startTime,
+        Integer spareTime,
+        Type type
+) {
+}

--- a/src/main/java/spring/backend/activity/dto/response/QuickStartsResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/QuickStartsResponse.java
@@ -1,8 +1,12 @@
 package spring.backend.activity.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record QuickStartsResponse(
+
+        @Schema(description = "빠른 시작 리스트")
         List<QuickStartResponse> quickStartResponses
 ) {
 }

--- a/src/main/java/spring/backend/activity/dto/response/QuickStartsResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/QuickStartsResponse.java
@@ -1,0 +1,8 @@
+package spring.backend.activity.dto.response;
+
+import java.util.List;
+
+public record QuickStartsResponse(
+        List<QuickStartResponse> quickStartResponses
+) {
+}

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/dao/QuickStartJpaDao.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/dao/QuickStartJpaDao.java
@@ -1,0 +1,28 @@
+package spring.backend.activity.infrastructure.persistence.jpa.dao;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import spring.backend.activity.dto.response.QuickStartResponse;
+import spring.backend.activity.infrastructure.persistence.jpa.entity.QuickStartJpaEntity;
+import spring.backend.activity.query.dao.QuickStartDao;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface QuickStartJpaDao extends JpaRepository<QuickStartJpaEntity, Long>, QuickStartDao {
+
+    @Override
+    @Query("""
+        select new spring.backend.activity.dto.response.QuickStartResponse(
+            q.id,
+            q.name,
+            q.startTime,
+            q.spareTime,
+            q.type
+        )
+        from QuickStartJpaEntity q
+        where q.memberId = :memberId
+    """)
+    List<QuickStartResponse> findByMemberId(UUID memberId, Sort sort);
+}

--- a/src/main/java/spring/backend/activity/presentation/ReadQuickStartsController.java
+++ b/src/main/java/spring/backend/activity/presentation/ReadQuickStartsController.java
@@ -1,0 +1,25 @@
+package spring.backend.activity.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import spring.backend.activity.application.ReadQuickStartsService;
+import spring.backend.activity.dto.response.QuickStartsResponse;
+import spring.backend.core.configuration.argumentresolver.LoginMember;
+import spring.backend.core.configuration.interceptor.Authorization;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.member.domain.entity.Member;
+
+@RestController
+@RequiredArgsConstructor
+public class ReadQuickStartsController {
+
+    private final ReadQuickStartsService readQuickStartsService;
+
+    @Authorization
+    @GetMapping("/v1/quick-starts")
+    public ResponseEntity<RestResponse<QuickStartsResponse>> readQuickStarts(@LoginMember Member member) {
+        return ResponseEntity.ok(new RestResponse<>(readQuickStartsService.readQuickStarts(member)));
+    }
+}

--- a/src/main/java/spring/backend/activity/presentation/ReadQuickStartsController.java
+++ b/src/main/java/spring/backend/activity/presentation/ReadQuickStartsController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.activity.application.ReadQuickStartsService;
 import spring.backend.activity.dto.response.QuickStartsResponse;
+import spring.backend.activity.presentation.swagger.ReadQuickStartsSwagger;
 import spring.backend.core.configuration.argumentresolver.LoginMember;
 import spring.backend.core.configuration.interceptor.Authorization;
 import spring.backend.core.presentation.RestResponse;
@@ -13,7 +14,7 @@ import spring.backend.member.domain.entity.Member;
 
 @RestController
 @RequiredArgsConstructor
-public class ReadQuickStartsController {
+public class ReadQuickStartsController implements ReadQuickStartsSwagger {
 
     private final ReadQuickStartsService readQuickStartsService;
 

--- a/src/main/java/spring/backend/activity/presentation/swagger/ReadQuickStartsSwagger.java
+++ b/src/main/java/spring/backend/activity/presentation/swagger/ReadQuickStartsSwagger.java
@@ -1,0 +1,24 @@
+package spring.backend.activity.presentation.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import spring.backend.activity.dto.response.QuickStartsResponse;
+import spring.backend.activity.exception.QuickStartErrorCode;
+import spring.backend.core.configuration.swagger.ApiErrorCode;
+import spring.backend.core.exception.error.GlobalErrorCode;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.member.domain.entity.Member;
+
+@Tag(name = "QuickStart", description = "빠른 시작")
+public interface ReadQuickStartsSwagger {
+
+    @Operation(
+            summary = "빠른 시작 리스트 조회 API",
+            description = "사용자가 생성한 빠른 시작 리스트를 반환합니다.",
+            operationId = "/v1/quick-starts"
+    )
+    @ApiErrorCode({GlobalErrorCode.class, QuickStartErrorCode.class})
+    ResponseEntity<RestResponse<QuickStartsResponse>> readQuickStarts(@Parameter(hidden = true) Member member);
+}

--- a/src/main/java/spring/backend/activity/query/dao/QuickStartDao.java
+++ b/src/main/java/spring/backend/activity/query/dao/QuickStartDao.java
@@ -1,0 +1,12 @@
+package spring.backend.activity.query.dao;
+
+import org.springframework.data.domain.Sort;
+import spring.backend.activity.dto.response.QuickStartResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface QuickStartDao {
+
+    List<QuickStartResponse> findByMemberId(UUID memberId, Sort sort);
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 빠른 시작 리스트 조회 API를 구현하였습니다.
- 빠른 시작 조회 전용 DAO를 작성하였습니다.
  - 외부 도메인을 같이 조회해서 보여줘야 할 때(홈 화면에서 빠른 시작과 활동을 보여주는 것.. etc) 
  - 쿼리를 각 도메인마다 조회해서 합치는 방식보다 한 쿼리를 잘 작성해서 한 번에 불러오는게 성능상 이점이 있어 사용해봤습니다.
  - findById나 findByEmail과 같은 조회 쿼리는 Dao에 넣는 것보다 기존 Repository에서 사용하고, 잦은 조회가 필요하거나 여러 도메인이 함께 조회될 때 DAO를 통해 조회 기능을 구현하려고 하고 있습니다.
- DAO도 마찬가지로 DIP를 통해 저수준 모듈이 고수준 모듈에 의존할 수 있게 하였고, 따로 어댑터 클래스는 만들지 않았습니다. 
  - 조회 결과가 없으면 어댑터에서 처리하는게 아니라 서비스 로직에서 처리하려고 합니다. (조회 결과가 없다고 에러처리를 할 필요가 없기 때문입니다.)
- 빠른 시작 id도 같이 반환하고 있습니다.
  - 추후 빠른 시작에서 바로 추천으로 넘어갈 때 id를 통한 빠른 시작을 조회하기 위해 같이 반환하였습니다.

### 응답 결과
![스크린샷 2024-10-30 오전 3 01 41](https://github.com/user-attachments/assets/4805cf1d-06e5-4f0d-b4c6-19495d847f1a)


---

## ✏️ 관련 이슈
- Resolves : #60 

---

## 🎸 기타 사항 or 추가 코멘트