### PR TITLE
Feat: (#67) 가입까지 전체 완료한 사용자를 ArgumentResolver에서 정보를 가져온다

### DIFF
--- a/src/main/java/spring/backend/activity/application/CreateQuickStartService.java
+++ b/src/main/java/spring/backend/activity/application/CreateQuickStartService.java
@@ -20,7 +20,6 @@ public class CreateQuickStartService {
 
     public Long createQuickStart(Member member, QuickStartRequest request) {
         validateRequest(request);
-        validateMember(member);
         QuickStart quickStart = QuickStart.create(member.getId(), request.name(), request.startTime(), request.spareTime(), request.type());
         QuickStart savedQuickStart = quickStartRepository.save(quickStart);
         return savedQuickStart.getId();
@@ -30,13 +29,6 @@ public class CreateQuickStartService {
         if (request == null) {
             log.error("[CreateQuickStartService] Invalid request.");
             throw QuickStartErrorCode.NOT_EXIST_QUICK_START_CONDITION.toException();
-        }
-    }
-
-    private void validateMember(Member member) {
-        if (!member.isMember()) {
-            log.error("[CreateQuickStartService] Client is not a member.");
-            throw QuickStartErrorCode.NOT_A_MEMBER.toException();
         }
     }
 }

--- a/src/main/java/spring/backend/activity/application/ReadQuickStartsService.java
+++ b/src/main/java/spring/backend/activity/application/ReadQuickStartsService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spring.backend.activity.dto.response.QuickStartResponse;
 import spring.backend.activity.dto.response.QuickStartsResponse;
-import spring.backend.activity.exception.QuickStartErrorCode;
 import spring.backend.activity.query.dao.QuickStartDao;
 import spring.backend.member.domain.entity.Member;
 
@@ -22,15 +21,7 @@ public class ReadQuickStartsService {
     private final QuickStartDao quickStartDao;
 
     public QuickStartsResponse readQuickStarts(Member member) {
-        validateMember(member);
         List<QuickStartResponse> quickStartResponses = quickStartDao.findByMemberId(member.getId(), Sort.by("createdAt").descending());
         return new QuickStartsResponse(quickStartResponses);
-    }
-
-    private void validateMember(Member member) {
-        if (!member.isMember()) {
-            log.error("[ReadQuickStartsService] Client is not a member.");
-            throw QuickStartErrorCode.NOT_A_MEMBER.toException();
-        }
     }
 }

--- a/src/main/java/spring/backend/activity/application/UpdateQuickStartService.java
+++ b/src/main/java/spring/backend/activity/application/UpdateQuickStartService.java
@@ -30,7 +30,6 @@ public class UpdateQuickStartService {
     private void validateUpdateRequest(Member member, QuickStartRequest request, QuickStart quickStart) {
         validateQuickStartExistence(quickStart);
         validateRequest(request);
-        validateMember(member);
         validateMemberId(member.getId(), quickStart.getMemberId());
     }
 
@@ -45,13 +44,6 @@ public class UpdateQuickStartService {
         if (request == null) {
             log.error("[validateRequest] Request is null.");
             throw QuickStartErrorCode.NOT_EXIST_QUICK_START_CONDITION.toException();
-        }
-    }
-
-    private void validateMember(Member member) {
-        if (!member.isMember()) {
-            log.error("[validateMember] Unauthorized member.");
-            throw QuickStartErrorCode.NOT_A_MEMBER.toException();
         }
     }
 

--- a/src/main/java/spring/backend/activity/exception/QuickStartErrorCode.java
+++ b/src/main/java/spring/backend/activity/exception/QuickStartErrorCode.java
@@ -12,7 +12,6 @@ public enum QuickStartErrorCode implements BaseErrorCode<DomainException> {
 
     QUICK_START_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "빠른 시작 정보를 저장하는데 실패하였습니다."),
     NOT_EXIST_QUICK_START_CONDITION(HttpStatus.BAD_REQUEST, "빠른 시작 요청 조건이 유효하지 않습니다."),
-    NOT_A_MEMBER(HttpStatus.FORBIDDEN, "사용자가 멤버 사용자가 아닙니다."),
     NOT_EXIST_QUICK_START(HttpStatus.BAD_REQUEST, "빠른 시작이 존재하지 않습니다."),
     MEMBER_ID_MISMATCH(HttpStatus.FORBIDDEN, "빠른 시작과 멤버 ID가 일치하지 않습니다.");
 

--- a/src/main/java/spring/backend/activity/presentation/CreateQuickStartController.java
+++ b/src/main/java/spring/backend/activity/presentation/CreateQuickStartController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import spring.backend.activity.application.CreateQuickStartService;
 import spring.backend.activity.dto.request.QuickStartRequest;
 import spring.backend.activity.presentation.swagger.CreateQuickStartSwagger;
-import spring.backend.core.configuration.argumentresolver.LoginMember;
+import spring.backend.core.configuration.argumentresolver.AuthorizedMember;
 import spring.backend.core.configuration.interceptor.Authorization;
 import spring.backend.core.presentation.RestResponse;
 import spring.backend.member.domain.entity.Member;
@@ -22,7 +22,7 @@ public class CreateQuickStartController implements CreateQuickStartSwagger {
 
     @Authorization
     @PostMapping("/v1/quick-starts")
-    public ResponseEntity<RestResponse<Long>> createQuickStart(@LoginMember Member member, @Valid @RequestBody QuickStartRequest request) {
+    public ResponseEntity<RestResponse<Long>> createQuickStart(@AuthorizedMember Member member, @Valid @RequestBody QuickStartRequest request) {
         Long memberId = createQuickStartService.createQuickStart(member, request);
         return ResponseEntity.ok(new RestResponse<>(memberId));
     }

--- a/src/main/java/spring/backend/activity/presentation/ReadQuickStartsController.java
+++ b/src/main/java/spring/backend/activity/presentation/ReadQuickStartsController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 import spring.backend.activity.application.ReadQuickStartsService;
 import spring.backend.activity.dto.response.QuickStartsResponse;
 import spring.backend.activity.presentation.swagger.ReadQuickStartsSwagger;
-import spring.backend.core.configuration.argumentresolver.LoginMember;
+import spring.backend.core.configuration.argumentresolver.AuthorizedMember;
 import spring.backend.core.configuration.interceptor.Authorization;
 import spring.backend.core.presentation.RestResponse;
 import spring.backend.member.domain.entity.Member;
@@ -20,7 +20,7 @@ public class ReadQuickStartsController implements ReadQuickStartsSwagger {
 
     @Authorization
     @GetMapping("/v1/quick-starts")
-    public ResponseEntity<RestResponse<QuickStartsResponse>> readQuickStarts(@LoginMember Member member) {
+    public ResponseEntity<RestResponse<QuickStartsResponse>> readQuickStarts(@AuthorizedMember Member member) {
         return ResponseEntity.ok(new RestResponse<>(readQuickStartsService.readQuickStarts(member)));
     }
 }

--- a/src/main/java/spring/backend/activity/presentation/UpdateQuickStartController.java
+++ b/src/main/java/spring/backend/activity/presentation/UpdateQuickStartController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import spring.backend.activity.application.UpdateQuickStartService;
 import spring.backend.activity.dto.request.QuickStartRequest;
 import spring.backend.activity.presentation.swagger.UpdateQuickStartSwagger;
-import spring.backend.core.configuration.argumentresolver.LoginMember;
+import spring.backend.core.configuration.argumentresolver.AuthorizedMember;
 import spring.backend.core.configuration.interceptor.Authorization;
 import spring.backend.member.domain.entity.Member;
 
@@ -22,7 +22,7 @@ public class UpdateQuickStartController implements UpdateQuickStartSwagger {
 
     @Authorization
     @PatchMapping("/v1/quick-starts/{quickStartId}")
-    public ResponseEntity<Void> updateQuickStart(@LoginMember Member member, @Valid @RequestBody QuickStartRequest request, @PathVariable Long quickStartId) {
+    public ResponseEntity<Void> updateQuickStart(@AuthorizedMember Member member, @Valid @RequestBody QuickStartRequest request, @PathVariable Long quickStartId) {
         updateQuickStartService.updateQuickStart(member, request, quickStartId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/spring/backend/core/configuration/WebMvcConfiguration.java
+++ b/src/main/java/spring/backend/core/configuration/WebMvcConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import spring.backend.core.configuration.argumentresolver.AuthorizedMemberArgumentResolver;
 import spring.backend.core.configuration.argumentresolver.LoginMemberArgumentResolver;
 import spring.backend.core.configuration.interceptor.AuthorizationInterceptor;
 
@@ -18,6 +19,8 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
     private final AuthorizationInterceptor authorizationInterceptor;
 
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    private final AuthorizedMemberArgumentResolver authorizedMemberArgumentResolver;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -36,5 +39,6 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberArgumentResolver);
+        resolvers.add(authorizedMemberArgumentResolver);
     }
 }

--- a/src/main/java/spring/backend/core/configuration/argumentresolver/AuthorizedMember.java
+++ b/src/main/java/spring/backend/core/configuration/argumentresolver/AuthorizedMember.java
@@ -1,0 +1,11 @@
+package spring.backend.core.configuration.argumentresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthorizedMember {
+}

--- a/src/main/java/spring/backend/core/configuration/argumentresolver/AuthorizedMemberArgumentResolver.java
+++ b/src/main/java/spring/backend/core/configuration/argumentresolver/AuthorizedMemberArgumentResolver.java
@@ -1,0 +1,32 @@
+package spring.backend.core.configuration.argumentresolver;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.exception.MemberErrorCode;
+
+@Component
+@RequiredArgsConstructor
+public class AuthorizedMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthorizedMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Member authorizedMember = (Member) loginMemberArgumentResolver.resolveArgument(parameter, mavContainer, webRequest, binderFactory);
+        if (authorizedMember == null || !authorizedMember.isMember()) {
+            throw MemberErrorCode.NOT_AUTHORIZED_MEMBER.toException();
+        }
+        return authorizedMember;
+    }
+}

--- a/src/main/java/spring/backend/member/exception/MemberErrorCode.java
+++ b/src/main/java/spring/backend/member/exception/MemberErrorCode.java
@@ -18,7 +18,8 @@ public enum MemberErrorCode implements BaseErrorCode<DomainException> {
     NOT_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임은 필수 입력값입니다."),
     INVALID_NICKNAME_LENGTH(HttpStatus.BAD_REQUEST, "닉네임은 1자에서 6자 사이여야 합니다."),
     INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "닉네임은 한글, 영문, 숫자 조합이어야 합니다."),
-    ALREADY_REGISTERED_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임이 이미 사용 중입니다.");
+    ALREADY_REGISTERED_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임이 이미 사용 중입니다."),
+    NOT_AUTHORIZED_MEMBER(HttpStatus.FORBIDDEN, "회원가입을 완료한 사용자가 아닙니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/test/java/spring/backend/activity/application/CreateQuickStartServiceTest.java
+++ b/src/test/java/spring/backend/activity/application/CreateQuickStartServiceTest.java
@@ -21,7 +21,8 @@ import java.sql.Time;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CreateQuickStartServiceTest {
@@ -33,16 +34,12 @@ class CreateQuickStartServiceTest {
     private QuickStartRepository quickStartRepository;
 
     private Member member;
-    private Member guest;
     private QuickStartRequest request;
 
     @BeforeEach
     public void setUp() {
         member = Member.builder()
                 .role(Role.MEMBER)
-                .build();
-        guest = Member.builder()
-                .role(Role.GUEST)
                 .build();
         request = new QuickStartRequest(
                 "등교",
@@ -60,16 +57,6 @@ class CreateQuickStartServiceTest {
 
         // then
         assertEquals(QuickStartErrorCode.NOT_EXIST_QUICK_START_CONDITION.getMessage(), ex.getMessage());
-    }
-
-    @DisplayName("비회원이 요청하는 경우 예외가 발생한다")
-    @Test
-    public void createQuickStart_NonMember_ThrowsException() {
-        // when
-        DomainException ex = assertThrows(DomainException.class, () -> createQuickStartService.createQuickStart(guest, request));
-
-        // then
-        assertEquals(QuickStartErrorCode.NOT_A_MEMBER.getMessage(), ex.getMessage());
     }
 
     @DisplayName("유효한 빠른 시작 요청인 경우 저장된 ID를 반환한다")

--- a/src/test/java/spring/backend/core/configuration/argumentresolver/AuthorizedMemberArgumentResolverTest.java
+++ b/src/test/java/spring/backend/core/configuration/argumentresolver/AuthorizedMemberArgumentResolverTest.java
@@ -1,0 +1,90 @@
+package spring.backend.core.configuration.argumentresolver;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import spring.backend.core.exception.DomainException;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.value.Role;
+import spring.backend.member.exception.MemberErrorCode;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AuthorizedMemberArgumentResolverTest {
+
+    @InjectMocks
+    private AuthorizedMemberArgumentResolver authorizedMemberArgumentResolver;
+
+    @Mock
+    private LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    @Mock
+    private NativeWebRequest webRequest;
+
+    @Mock
+    private ModelAndViewContainer mavContainer;
+
+    private Member member;
+    private Member guest;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        member = Member.builder()
+                .id(UUID.randomUUID())
+                .role(Role.MEMBER)
+                .build();
+        guest = Member.builder()
+                .id(UUID.randomUUID())
+                .role(Role.GUEST)
+                .build();
+    }
+
+    @DisplayName("AuthorizedMember 어노테이션이 있는 경우 지원한다")
+    @Test
+    public void supportsParameterReturnsTrueForLoginMember() {
+        MethodParameter parameter = mock(MethodParameter.class);
+        when(parameter.hasParameterAnnotation(AuthorizedMember.class)).thenReturn(true);
+        Assertions.assertTrue(authorizedMemberArgumentResolver.supportsParameter(parameter));
+    }
+
+    @DisplayName("Authorization 헤더에 유효한 토큰이 있을 때 AuthorizedMember 객체를 반환한다")
+    @Test
+    public void returnsAuthorizedMemberObject_whenAuthorizationHeaderIsProvided() throws Exception {
+        // when
+        MethodParameter parameter = mock(MethodParameter.class);
+        when(parameter.hasParameterAnnotation(AuthorizedMember.class)).thenReturn(true);
+        when(loginMemberArgumentResolver.resolveArgument(parameter, mavContainer, webRequest, null)).thenReturn(member);
+
+        // then
+        Object result = authorizedMemberArgumentResolver.resolveArgument(parameter, mavContainer, webRequest, null);
+        assertNotNull(result);
+        assertThat(result).isEqualTo(member);
+    }
+
+    @DisplayName("Authorization 헤더에 유효한 토큰이 있을 때 Guest인 경우 예외를 발생시킨다")
+    @Test
+    public void throwsNotAuthorizedMemberException_whenGuestMemberIsProvided() throws Exception {
+        // when
+        MethodParameter parameter = mock(MethodParameter.class);
+        when(parameter.hasParameterAnnotation(AuthorizedMember.class)).thenReturn(true);
+        when(loginMemberArgumentResolver.resolveArgument(parameter, mavContainer, webRequest, null)).thenReturn(guest);
+
+        // then
+        DomainException exception = assertThrows(DomainException.class, () -> authorizedMemberArgumentResolver.resolveArgument(parameter, mavContainer, webRequest, null));
+        assertThat(exception.getCode()).isEqualTo(MemberErrorCode.NOT_AUTHORIZED_MEMBER.name());
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- ArgumentResolver와 AuthorizedMember 어노테이션을 추가해서 작업하였습니다.
- 기존 Member인지 검증하는 로직을 제거하고, @AuthorizedMember 를 추가하였습니다.

### GUEST일 때 에러 응답
![스크린샷 2024-11-01 오전 2 46 23](https://github.com/user-attachments/assets/1bf8c8bc-4224-4ba5-aa90-cef4a3f244fb)
 

---

## ✏️ 관련 이슈
- Resolves : #67 

---

## 🎸 기타 사항 or 추가 코멘트
- LoginMember : 회원가입까지 모두 한 사용자 + 온보딩 가입 하지 않은 사용자
- AuthorizedMember : 회원가입까지 모두 한 사용자

> 어노테이션으로 관리하기!! (+Authorization 토큰 존재 유무 어노테이션도!)
> 매번 놓치더라구요..