### PR TITLE
Fix: (#73) 빠른 시작 startTime을 서버에서 변환하여 저장한다

### DIFF
--- a/src/main/java/spring/backend/activity/application/CreateQuickStartService.java
+++ b/src/main/java/spring/backend/activity/application/CreateQuickStartService.java
@@ -8,7 +8,10 @@ import spring.backend.activity.domain.entity.QuickStart;
 import spring.backend.activity.domain.repository.QuickStartRepository;
 import spring.backend.activity.dto.request.QuickStartRequest;
 import spring.backend.activity.exception.QuickStartErrorCode;
+import spring.backend.core.util.TimeUtil;
 import spring.backend.member.domain.entity.Member;
+
+import java.time.LocalTime;
 
 @Service
 @RequiredArgsConstructor
@@ -20,7 +23,11 @@ public class CreateQuickStartService {
 
     public Long createQuickStart(Member member, QuickStartRequest request) {
         validateRequest(request);
-        QuickStart quickStart = QuickStart.create(member.getId(), request.name(), request.startTime(), request.spareTime(), request.type());
+
+        LocalTime startTime = TimeUtil.toLocalTime(request.meridiem(), request.hour(), request.minute());
+        validateStartTime(startTime);
+
+        QuickStart quickStart = QuickStart.create(member.getId(), request.name(), startTime, request.spareTime(), request.type());
         QuickStart savedQuickStart = quickStartRepository.save(quickStart);
         return savedQuickStart.getId();
     }
@@ -29,6 +36,13 @@ public class CreateQuickStartService {
         if (request == null) {
             log.error("[CreateQuickStartService] Invalid request.");
             throw QuickStartErrorCode.NOT_EXIST_QUICK_START_CONDITION.toException();
+        }
+    }
+
+    private void validateStartTime(LocalTime time) {
+        if (time == null) {
+            log.error("[CreateQuickStartService] Invalid start time.");
+            throw QuickStartErrorCode.START_TIME_CONVERSION_FAILED.toException();
         }
     }
 }

--- a/src/main/java/spring/backend/activity/application/UpdateQuickStartService.java
+++ b/src/main/java/spring/backend/activity/application/UpdateQuickStartService.java
@@ -8,8 +8,10 @@ import spring.backend.activity.domain.entity.QuickStart;
 import spring.backend.activity.domain.repository.QuickStartRepository;
 import spring.backend.activity.dto.request.QuickStartRequest;
 import spring.backend.activity.exception.QuickStartErrorCode;
+import spring.backend.core.util.TimeUtil;
 import spring.backend.member.domain.entity.Member;
 
+import java.time.LocalTime;
 import java.util.UUID;
 
 @Service
@@ -23,7 +25,11 @@ public class UpdateQuickStartService {
     public void updateQuickStart(Member member, QuickStartRequest request, Long quickStartId) {
         QuickStart quickStart = quickStartRepository.findById(quickStartId);
         validateUpdateRequest(member, request, quickStart);
-        quickStart.update(request.name(), request.startTime(), request.spareTime(), request.type());
+
+        LocalTime startTime = TimeUtil.toLocalTime(request.meridiem(), request.hour(), request.minute());
+        validateStartTime(startTime);
+
+        quickStart.update(request.name(), startTime, request.spareTime(), request.type());
         quickStartRepository.save(quickStart);
     }
 
@@ -51,6 +57,13 @@ public class UpdateQuickStartService {
         if (!memberId.equals(quickStartMemberId)) {
             log.error("[validateMemberId] Member id mismatch");
             throw QuickStartErrorCode.MEMBER_ID_MISMATCH.toException();
+        }
+    }
+
+    private void validateStartTime(LocalTime time) {
+        if (time == null) {
+            log.error("[UpdateQuickStartService] Invalid start time.");
+            throw QuickStartErrorCode.START_TIME_CONVERSION_FAILED.toException();
         }
     }
 }

--- a/src/main/java/spring/backend/activity/dto/request/QuickStartRequest.java
+++ b/src/main/java/spring/backend/activity/dto/request/QuickStartRequest.java
@@ -4,8 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import spring.backend.activity.domain.value.Type;
 
-import java.time.LocalTime;
-
 public record QuickStartRequest(
 
         @NotNull(message = "이름은 필수 입력 항목입니다.")
@@ -14,9 +12,22 @@ public record QuickStartRequest(
         @Schema(description = "빠른 시작 이름", example = "등교")
         String name,
 
-        @NotNull(message = "시작 시간은 필수 입력 항목입니다.")
-        @Schema(description = "시작 시간", example = "12:30")
-        LocalTime startTime,
+        @NotNull(message = "시작 시간의 시간은 필수 입력 항목입니다.")
+        @Min(value = 0, message = "시작 시간의 시간은 최소 0이어야 합니다.")
+        @Max(value = 12, message = "시작 시간의 시간은 최대 12이어야 합니다.")
+        @Schema(description = "시작 시간의 시간", example = "12")
+        Integer hour,
+
+        @NotNull(message = "시작 시간의 분은 필수 입력 항목입니다.")
+        @Min(value = 0, message = "시작 시간의 분은 최소 0이어야 합니다.")
+        @Max(value = 59, message = "시작 시간의 분은 최대 59이어야 합니다.")
+        @Schema(description = "시작 시간의 분", example = "30")
+        Integer minute,
+
+        @NotNull(message = "오전/오후 표시는 필수 입력 항목입니다.")
+        @Pattern(regexp = "^(오전|오후)$", message = "meridiem은 '오전' 또는 '오후'여야 합니다.")
+        @Schema(description = "오전/오후 표시", example = "오후")
+        String meridiem,
 
         @NotNull(message = "자투리 시간은 필수 입력 항목입니다.")
         @Min(value = 10, message = "자투리 시간은 최소 10이어야 합니다.")

--- a/src/main/java/spring/backend/activity/dto/response/QuickStartResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/QuickStartResponse.java
@@ -2,6 +2,7 @@ package spring.backend.activity.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import spring.backend.activity.domain.value.Type;
+import spring.backend.core.util.TimeUtil;
 
 import java.time.LocalTime;
 
@@ -20,6 +21,18 @@ public record QuickStartResponse(
         Integer spareTime,
 
         @Schema(description = "활동 유형 (ONLINE, OFFLINE, ONLINE_AND_OFFLINE)", example = "ONLINE")
-        Type type
+        Type type,
+
+        @Schema(description = "시작 시간의 시", example = "12")
+        Integer hour,
+
+        @Schema(description = "시작 시간의 분", example = "30")
+        Integer minute,
+
+        @Schema(description = "오전/오후 표시", example = "오후")
+        String meridiem
 ) {
+        public QuickStartResponse(Long id, String name, LocalTime startTime, Integer spareTime, Type type) {
+                this(id, name, startTime, spareTime, type, TimeUtil.toHour(startTime), TimeUtil.toMinute(startTime), TimeUtil.toMeridiem(startTime));
+        }
 }

--- a/src/main/java/spring/backend/activity/exception/QuickStartErrorCode.java
+++ b/src/main/java/spring/backend/activity/exception/QuickStartErrorCode.java
@@ -13,7 +13,8 @@ public enum QuickStartErrorCode implements BaseErrorCode<DomainException> {
     QUICK_START_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "빠른 시작 정보를 저장하는데 실패하였습니다."),
     NOT_EXIST_QUICK_START_CONDITION(HttpStatus.BAD_REQUEST, "빠른 시작 요청 조건이 유효하지 않습니다."),
     NOT_EXIST_QUICK_START(HttpStatus.BAD_REQUEST, "빠른 시작이 존재하지 않습니다."),
-    MEMBER_ID_MISMATCH(HttpStatus.FORBIDDEN, "빠른 시작과 멤버 ID가 일치하지 않습니다.");
+    MEMBER_ID_MISMATCH(HttpStatus.FORBIDDEN, "빠른 시작과 멤버 ID가 일치하지 않습니다."),
+    START_TIME_CONVERSION_FAILED(HttpStatus.BAD_REQUEST, "빠른 시작 시작 시간 변환에 실패하였습니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/spring/backend/core/util/TimeUtil.java
+++ b/src/main/java/spring/backend/core/util/TimeUtil.java
@@ -1,0 +1,52 @@
+package spring.backend.core.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.DateTimeException;
+import java.time.LocalTime;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TimeUtil {
+
+    private static final String ANTE_MERIDIEM = "오전";
+
+    private static final String POST_MERIDIEM = "오후";
+
+    public static LocalTime toLocalTime(String meridiem, Integer hour, Integer minute) {
+        if (meridiem == null || hour == null || minute == null) {
+            return null;
+        }
+        try {
+            return switch (meridiem) {
+                case ANTE_MERIDIEM -> LocalTime.of(hour % 12, minute);
+                case POST_MERIDIEM -> LocalTime.of((hour % 12) + 12, minute);
+                default -> null;
+            };
+        } catch (DateTimeException e) {
+            return null;
+        }
+    }
+
+    public static String toMeridiem(LocalTime time) {
+        if (time == null) {
+            return null;
+        }
+        return time.getHour() < 12 ? ANTE_MERIDIEM : POST_MERIDIEM;
+    }
+
+    public static Integer toHour(LocalTime time) {
+        if (time == null) {
+            return null;
+        }
+        int hour = time.getHour() % 12;
+        return hour == 0 ? 12 : hour;
+    }
+
+    public static Integer toMinute(LocalTime time) {
+        if (time == null) {
+            return null;
+        }
+        return time.getMinute();
+    }
+}

--- a/src/test/java/spring/backend/activity/application/CreateQuickStartServiceTest.java
+++ b/src/test/java/spring/backend/activity/application/CreateQuickStartServiceTest.java
@@ -13,6 +13,7 @@ import spring.backend.activity.domain.value.Type;
 import spring.backend.activity.dto.request.QuickStartRequest;
 import spring.backend.activity.exception.QuickStartErrorCode;
 import spring.backend.core.exception.DomainException;
+import spring.backend.core.util.TimeUtil;
 import spring.backend.member.domain.entity.Member;
 import spring.backend.member.domain.value.Role;
 
@@ -43,7 +44,9 @@ class CreateQuickStartServiceTest {
                 .build();
         request = new QuickStartRequest(
                 "등교",
-                LocalTime.of(12, 30),
+                12,
+                30,
+                "오전",
                 300,
                 Type.ONLINE
         );
@@ -62,7 +65,8 @@ class CreateQuickStartServiceTest {
     @DisplayName("유효한 빠른 시작 요청인 경우 저장된 ID를 반환한다")
     @Test
     public void createQuickStart_ValidRequest_ReturnsSavedQuickStartId() {
-        QuickStart quickStart = QuickStart.create(member.getId(), request.name(), request.startTime(), request.spareTime(), request.type());
+        LocalTime startTime = TimeUtil.toLocalTime(request.meridiem(), request.hour(), request.minute());
+        QuickStart quickStart = QuickStart.create(member.getId(), request.name(), startTime, request.spareTime(), request.type());
         when(quickStartRepository.save(any(QuickStart.class))).thenReturn(quickStart);
 
         // when

--- a/src/test/java/spring/backend/activity/dto/request/QuickStartRequestTest.java
+++ b/src/test/java/spring/backend/activity/dto/request/QuickStartRequestTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import spring.backend.activity.domain.value.Type;
 
-import java.time.LocalTime;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +32,7 @@ class QuickStartRequestTest {
         @Test
         @DisplayName("null 값일 경우 에러가 발생한다.")
         void whenNameIsNull_thenValidationFails() {
-            QuickStartRequest request = new QuickStartRequest(null, LocalTime.now(), 300, Type.OFFLINE);
+            QuickStartRequest request = new QuickStartRequest(null, 12, 30, "오전", 300, Type.OFFLINE);
             Set<ConstraintViolation<QuickStartRequest>> violations = validator.validate(request);
 
             assertThat(violations).isNotEmpty();
@@ -44,7 +43,7 @@ class QuickStartRequestTest {
         @DisplayName("올바른 형식의 이름일 경우 성공한다.")
         @ValueSource(strings = {"등교", "이름테스트", "John Doe", "사용자1"})
         void whenNameIsValid_thenValidationSucceeds(String name) {
-            QuickStartRequest request = new QuickStartRequest(name, LocalTime.now(), 300, Type.OFFLINE);
+            QuickStartRequest request = new QuickStartRequest(name, 12, 30, "오전", 300, Type.OFFLINE);
             Set<ConstraintViolation<QuickStartRequest>> violations = validator.validate(request);
 
             assertThat(violations).isEmpty();
@@ -54,7 +53,7 @@ class QuickStartRequestTest {
         @DisplayName("형식에 맞지 않는 이름일 경우 에러가 발생한다.")
         @ValueSource(strings = {" 이름", "이름 ", "이름@이름", "공백  공백"})
         void whenNameIsInvalid_thenValidationFails(String name) {
-            QuickStartRequest request = new QuickStartRequest(name, LocalTime.now(), 300, Type.OFFLINE);
+            QuickStartRequest request = new QuickStartRequest(name, 12, 30, "오전", 300, Type.OFFLINE);
             Set<ConstraintViolation<QuickStartRequest>> violations = validator.validate(request);
 
             assertThat(violations).isNotEmpty();
@@ -65,7 +64,7 @@ class QuickStartRequestTest {
         @DisplayName("10자를 초과하는 경우 에러가 발생한다.")
         void whenNameExceedsMaxLength_thenValidationFails() {
             String name = "매우몹시너무긴이름longname";
-            QuickStartRequest request = new QuickStartRequest(name, LocalTime.now(), 300, Type.OFFLINE);
+            QuickStartRequest request = new QuickStartRequest(name, 12, 30, "오전", 300, Type.OFFLINE);
             Set<ConstraintViolation<QuickStartRequest>> violations = validator.validate(request);
 
             assertThat(violations).isNotEmpty();

--- a/src/test/java/spring/backend/core/util/TimeUtilTest.java
+++ b/src/test/java/spring/backend/core/util/TimeUtilTest.java
@@ -1,0 +1,53 @@
+package spring.backend.core.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TimeUtilTest {
+
+    @DisplayName("오전 10시 30분을 입력하면 10시 30분으로 변환된다.")
+    @Test
+    void testToLocalTime_AM() {
+        LocalTime time = TimeUtil.toLocalTime("오전", 10, 30);
+        assertEquals(10, time.getHour());
+        assertEquals(30, time.getMinute());
+    }
+
+    @DisplayName("오후 10시 30분을 입력하면 22시 30분으로 변환된다.")
+    @Test
+    void testToLocalTime_PM() {
+        LocalTime time = TimeUtil.toLocalTime("오후", 10, 30);
+        assertEquals(22, time.getHour());
+        assertEquals(30, time.getMinute());
+    }
+
+    @DisplayName("오전 0시 입력 시 '오전' 반환")
+    @Test
+    void testToMeridiem_Midnight() {
+        LocalTime time = LocalTime.of(0, 0);
+        String meridiem = TimeUtil.toMeridiem(time);
+        assertEquals("오전", meridiem);
+    }
+
+    @DisplayName("오후 12시 입력 시 '오후' 반환")
+    @Test
+    void testToMeridiem_Noon() {
+        LocalTime time = LocalTime.of(12, 0);
+        String meridiem = TimeUtil.toMeridiem(time);
+        assertEquals("오후", meridiem);
+    }
+
+    @DisplayName("오전 0시, 오후 12시는 12로 변환된다.")
+    @Test
+    void testToHour() {
+        LocalTime time = LocalTime.of(0, 0);
+        assertEquals(12, TimeUtil.toHour(time));
+
+        time = LocalTime.of(12, 0);
+        assertEquals(12, TimeUtil.toHour(time));
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 기존의 빠른 시작 시작 시간 처리를 프론트에서 변경 요청하셔서 논의 후 시, 분, 오전/오후 필드를 추가하기로 하였습니다.
- 프론트에서 보내주면 서버에서 TimeUtil 클래스를 통해 db에 변환하여 저장, 조회합니다.
- 빠른시작 조회, 수정, 작성 테스트 하였습니다.

### 성공 응답
![스크린샷 2024-11-03 오후 8 04 17](https://github.com/user-attachments/assets/f272eb20-c361-40ce-a540-9543d38fb5b0)

![스크린샷 2024-11-03 오후 8 12 12](https://github.com/user-attachments/assets/6eb844dd-09c3-42fe-b185-71b10bb18086)
---

## ✏️ 관련 이슈
- Fixes : #58 #60 #62 
- Resolves : #73 

---

## 🎸 기타 사항 or 추가 코멘트