### PR TITLE
Feat: (#77) 활동 종료 API를 구현한다

### DIFF
--- a/src/main/java/spring/backend/activity/application/FinishActivityService.java
+++ b/src/main/java/spring/backend/activity/application/FinishActivityService.java
@@ -1,0 +1,44 @@
+package spring.backend.activity.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import spring.backend.activity.domain.entity.Activity;
+import spring.backend.activity.domain.repository.ActivityRepository;
+import spring.backend.activity.dto.response.ActivityInfo;
+import spring.backend.activity.dto.response.FinishActivityResponse;
+import spring.backend.activity.exception.ActivityErrorCode;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.dto.response.HomeMemberInfoResponse;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+@Transactional
+public class FinishActivityService {
+
+    private final ActivityRepository activityRepository;
+
+    public FinishActivityResponse finishActivity(Member member, Long activityId) {
+        Activity activity = activityRepository.findById(activityId);
+        validateActivity(activity, member);
+        activity.finish();
+        activityRepository.save(activity);
+        return toResponse(member, activity);
+    }
+
+    private void validateActivity(Activity activity, Member member) {
+        if (activity == null) {
+            log.error("[FinishActivityService.validateActivity] activity is null");
+            throw ActivityErrorCode.NOT_EXIST_ACTIVITY.toException();
+        }
+        activity.validateActivityOwner(member.getId());
+    }
+
+    private FinishActivityResponse toResponse(Member member, Activity activity) {
+        HomeMemberInfoResponse memberInfo = HomeMemberInfoResponse.from(member);
+        ActivityInfo activityInfo = ActivityInfo.from(activity);
+        return new FinishActivityResponse(memberInfo, activityInfo);
+    }
+}

--- a/src/main/java/spring/backend/activity/domain/entity/Activity.java
+++ b/src/main/java/spring/backend/activity/domain/entity/Activity.java
@@ -4,13 +4,17 @@ import lombok.Builder;
 import lombok.Getter;
 import spring.backend.activity.domain.value.Keyword;
 import spring.backend.activity.domain.value.Type;
+import spring.backend.activity.exception.ActivityErrorCode;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 @Getter
 @Builder
 public class Activity {
+
+    public static final Integer MAX_SAVED_TIME = 300;
 
     private Long id;
 
@@ -41,4 +45,31 @@ public class Activity {
     private LocalDateTime updatedAt;
 
     private Boolean deleted;
+
+    public void validateActivityOwner(UUID memberId) {
+        if (!this.memberId.equals(memberId)) {
+            throw ActivityErrorCode.MEMBER_ID_MISMATCH.toException();
+        }
+    }
+
+    public boolean isFinished() {
+        return finished != null && finished;
+    }
+
+    public void finish() {
+        if (isFinished()) {
+            throw ActivityErrorCode.ALREADY_FINISHED_ACTIVITY.toException();
+        }
+        finished = true;
+        finishedAt = LocalDateTime.now();
+        savedTime = calculateSavedTime();
+    }
+
+    private Integer calculateSavedTime() {
+        long savedTime = ChronoUnit.MINUTES.between(createdAt, finishedAt);
+        if (savedTime < 0 || savedTime > MAX_SAVED_TIME) {
+            throw ActivityErrorCode.INVALID_ACTIVITY_DURATION.toException();
+        }
+        return Math.toIntExact(savedTime);
+    }
 }

--- a/src/main/java/spring/backend/activity/dto/response/ActivityInfo.java
+++ b/src/main/java/spring/backend/activity/dto/response/ActivityInfo.java
@@ -1,0 +1,27 @@
+package spring.backend.activity.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import spring.backend.activity.domain.entity.Activity;
+import spring.backend.activity.domain.value.Keyword;
+
+public record ActivityInfo(
+
+        @Schema(description = "활동 ID", example = "1")
+        Long id,
+
+        @Schema(description = "활동 키워드", example = "{\"category\": \"SELF_DEVELOPMENT\", \"image\": \"https://example.com/image.jpg\"}")
+        Keyword keyword,
+
+        @Schema(description = "활동 제목", example = "휴식에는 역시 명상이 최고!")
+        String title,
+
+        @Schema(description = "활동 내용", example = "마음의 편안을 가져다주는 명상음악 20분 듣기")
+        String content,
+
+        @Schema(description = "모은 시간", example = "20")
+        Integer savedTime
+) {
+    public static ActivityInfo from(Activity activity) {
+        return new ActivityInfo(activity.getId(), activity.getKeyword(), activity.getTitle(), activity.getContent(), activity.getSavedTime());
+    }
+}

--- a/src/main/java/spring/backend/activity/dto/response/FinishActivityResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/FinishActivityResponse.java
@@ -1,0 +1,14 @@
+package spring.backend.activity.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import spring.backend.member.dto.response.HomeMemberInfoResponse;
+
+public record FinishActivityResponse(
+
+        @Schema(description = "회원 정보")
+        HomeMemberInfoResponse member,
+
+        @Schema(description = "활동 정보")
+        ActivityInfo activity
+) {
+}

--- a/src/main/java/spring/backend/activity/exception/ActivityErrorCode.java
+++ b/src/main/java/spring/backend/activity/exception/ActivityErrorCode.java
@@ -10,7 +10,11 @@ import spring.backend.core.exception.error.BaseErrorCode;
 @RequiredArgsConstructor
 public enum ActivityErrorCode implements BaseErrorCode<DomainException> {
 
-    ACTIVITY_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "활동을 저장하는데 실패하였습니다.");
+    ACTIVITY_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "활동을 저장하는데 실패하였습니다."),
+    NOT_EXIST_ACTIVITY(HttpStatus.BAD_REQUEST, "활동이 존재하지 않습니다."),
+    MEMBER_ID_MISMATCH(HttpStatus.FORBIDDEN, "활동과 멤버 ID가 일치하지 않습니다."),
+    INVALID_ACTIVITY_DURATION(HttpStatus.BAD_REQUEST, "활동 지속 시간이 허용된 범위를 초과했습니다."),
+    ALREADY_FINISHED_ACTIVITY(HttpStatus.BAD_REQUEST, "이미 종료된 활동입니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/spring/backend/activity/presentation/FinishActivityController.java
+++ b/src/main/java/spring/backend/activity/presentation/FinishActivityController.java
@@ -1,0 +1,26 @@
+package spring.backend.activity.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import spring.backend.activity.application.FinishActivityService;
+import spring.backend.activity.dto.response.FinishActivityResponse;
+import spring.backend.core.configuration.argumentresolver.AuthorizedMember;
+import spring.backend.core.configuration.interceptor.Authorization;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.member.domain.entity.Member;
+
+@RestController
+@RequiredArgsConstructor
+public class FinishActivityController {
+
+    private final FinishActivityService finishActivityService;
+
+    @Authorization
+    @PatchMapping("/v1/activities/{activityId}/end")
+    public ResponseEntity<RestResponse<FinishActivityResponse>> finishActivity(@AuthorizedMember Member member, @PathVariable Long activityId) {
+        return ResponseEntity.ok(new RestResponse<>(finishActivityService.finishActivity(member, activityId)));
+    }
+}

--- a/src/main/java/spring/backend/activity/presentation/FinishActivityController.java
+++ b/src/main/java/spring/backend/activity/presentation/FinishActivityController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.activity.application.FinishActivityService;
 import spring.backend.activity.dto.response.FinishActivityResponse;
+import spring.backend.activity.presentation.swagger.FinishActivitySwagger;
 import spring.backend.core.configuration.argumentresolver.AuthorizedMember;
 import spring.backend.core.configuration.interceptor.Authorization;
 import spring.backend.core.presentation.RestResponse;
@@ -14,12 +15,12 @@ import spring.backend.member.domain.entity.Member;
 
 @RestController
 @RequiredArgsConstructor
-public class FinishActivityController {
+public class FinishActivityController implements FinishActivitySwagger {
 
     private final FinishActivityService finishActivityService;
 
     @Authorization
-    @PatchMapping("/v1/activities/{activityId}/end")
+    @PatchMapping("/v1/activities/{activityId}/finish")
     public ResponseEntity<RestResponse<FinishActivityResponse>> finishActivity(@AuthorizedMember Member member, @PathVariable Long activityId) {
         return ResponseEntity.ok(new RestResponse<>(finishActivityService.finishActivity(member, activityId)));
     }

--- a/src/main/java/spring/backend/activity/presentation/swagger/FinishActivitySwagger.java
+++ b/src/main/java/spring/backend/activity/presentation/swagger/FinishActivitySwagger.java
@@ -1,0 +1,24 @@
+package spring.backend.activity.presentation.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import spring.backend.activity.dto.response.FinishActivityResponse;
+import spring.backend.activity.exception.ActivityErrorCode;
+import spring.backend.core.configuration.swagger.ApiErrorCode;
+import spring.backend.core.exception.error.GlobalErrorCode;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.member.domain.entity.Member;
+
+@Tag(name = "Activity", description = "활동")
+public interface FinishActivitySwagger {
+
+    @Operation(
+            summary = "활동 종료 API",
+            description = "진행 중인 활동을 종료합니다. \n\n 이 API는 활동이 자투리 시간 내에서만 종료될 수 있습니다.",
+            operationId = "/v1/activities/{activityId}/finish"
+    )
+    @ApiErrorCode({GlobalErrorCode.class, ActivityErrorCode.class})
+    ResponseEntity<RestResponse<FinishActivityResponse>> finishActivity(@Parameter(hidden = true) Member member, Long activityId);
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 활동 종료 API를 구현했습니다.
- 활동 종료 방식은 2가지가 있습니다.
  - 활동 종료 - 활동 시작 시간이 자투리 시간을 넘을 경우, 자동으로 종료시킨다.
  - 활동 종료 - 활동 시작 시간이 자투리 시간을 넘지 않을 경우, 사용자가 활동 종료를 할 수 있다. (이번 작업)

### 성공 응답
![스크린샷 2024-11-04 오후 5 41 00](https://github.com/user-attachments/assets/db335be7-5a66-44a5-8d25-ae2094b54071)

### 실패 응답 - 이미 종료된 활동인 경우
![스크린샷 2024-11-04 오후 5 53 05](https://github.com/user-attachments/assets/e85e4ae8-dd91-4d90-afc1-663bd81f9369)

### 실패 응답 - 저장 시간이 300분 초과 혹은 0분 이하일 경우
![스크린샷 2024-11-04 오후 5 53 57](https://github.com/user-attachments/assets/9cd4fb6d-2d69-46b8-b7a4-f862a9b1dfe1)


---

## ✏️ 관련 이슈
- Resolves : #77 

---

## 🎸 기타 사항 or 추가 코멘트
- 자동 종료 기능은 다음 이슈에서 작업할 예정입니다.