### PR TITLE
Feat: (#78) 자투리 시간을 초과한 활동은 자동으로 종료처리한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ dependencies {
 	// Email
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	// Rabbit MQ
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+	testImplementation 'org.springframework.amqp:spring-rabbit-test'
 }
 
 tasks.named('test') {

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -21,8 +21,24 @@ services:
     networks:
       - cnergy-backend-network
 
+  rabbit:
+    container_name: cnergy-rabbitmq
+    hostname: cnergy-rabbit
+    image: heidiks/rabbitmq-delayed-message-exchange:4.0.2-management
+    environment:
+      - RABBITMQ_DEFAULT_USER=admin
+      - RABBITMQ_DEFAULT_PASS=password
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    networks:
+      - cnergy-backend-network
+
 volumes:
   redis-data:
+  rabbitmq-data:
 
 networks:
   cnergy-backend-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,26 @@ services:
     networks:
       - cnergy-backend-network
 
+  rabbit:
+    container_name: cnergy-rabbitmq
+    hostname: cnergy-rabbit
+    image: heidiks/rabbitmq-delayed-message-exchange:4.0.2-management
+    environment:
+      - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
+      - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    env_file:
+      - .env
+    volumes:
+      - rabbitmq-data:/var/lib/rabbitmq
+    networks:
+      - cnergy-backend-network
+
 volumes:
   redis-data:
+  rabbitmq-data:
 
 networks:
   cnergy-backend-network:

--- a/src/main/java/spring/backend/activity/application/FinishActivityAutoService.java
+++ b/src/main/java/spring/backend/activity/application/FinishActivityAutoService.java
@@ -1,0 +1,28 @@
+package spring.backend.activity.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import spring.backend.activity.domain.entity.Activity;
+import spring.backend.activity.infrastructure.queue.FinishActivityMessage;
+import spring.backend.activity.infrastructure.queue.FinishActivityMessageProducer;
+import spring.backend.core.configuration.property.queue.FinishActivityQueueProperty;
+
+@Service
+@RequiredArgsConstructor
+public class FinishActivityAutoService {
+
+    private final FinishActivityQueueProperty finishActivityQueueProperty;
+
+    public void finishActivityAuto(Activity activity) {
+        int spareTime = activity.getSpareTime();
+        FinishActivityMessageProducer finishActivityMessageProducer = new FinishActivityMessageProducer(
+                finishActivityQueueProperty,
+                FinishActivityMessage.builder()
+                        .activityId(activity.getId())
+                        .spareTime(spareTime)
+                        .build()
+        );
+        long delayTime = (long) spareTime * 60 * 1000;
+        finishActivityMessageProducer.publishMessageWithDelay(delayTime);
+    }
+}

--- a/src/main/java/spring/backend/activity/application/QuickStartActivitySelectService.java
+++ b/src/main/java/spring/backend/activity/application/QuickStartActivitySelectService.java
@@ -20,13 +20,14 @@ import spring.backend.member.domain.entity.Member;
 public class QuickStartActivitySelectService {
     private final ActivityRepository activityRepository;
     private final QuickStartRepository quickStartRepository;
+    private final FinishActivityAutoService finishActivityAutoService;
 
-    public QuickStartActivitySelectResponse quickStartUserActivitySelect(Member member, Long quickStartId, QuickStartActivitySelectRequest quickStartActivitySelectRequest
-    ) {
+    public QuickStartActivitySelectResponse quickStartUserActivitySelect(Member member, Long quickStartId, QuickStartActivitySelectRequest quickStartActivitySelectRequest) {
         validateQuickStart(quickStartId);
         validateRequest(quickStartActivitySelectRequest);
         Activity activity = Activity.create(member.getId(), quickStartId, quickStartActivitySelectRequest.spareTime(), quickStartActivitySelectRequest.type(), quickStartActivitySelectRequest.keyword(), quickStartActivitySelectRequest.title(), quickStartActivitySelectRequest.content(), quickStartActivitySelectRequest.location());
         Activity savedActivity = activityRepository.save(activity);
+        finishActivityAutoService.finishActivityAuto(savedActivity);
         return new QuickStartActivitySelectResponse(savedActivity.getId(), savedActivity.getTitle(), savedActivity.getKeyword());
     }
 

--- a/src/main/java/spring/backend/activity/application/UserActivitySelectService.java
+++ b/src/main/java/spring/backend/activity/application/UserActivitySelectService.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spring.backend.activity.domain.entity.Activity;
 import spring.backend.activity.domain.repository.ActivityRepository;
-import spring.backend.activity.domain.value.Keyword;
 import spring.backend.activity.dto.request.UserActivitySelectRequest;
 import spring.backend.activity.dto.response.UserActivitySelectResponse;
 import spring.backend.activity.exception.ActivityErrorCode;
@@ -20,10 +19,13 @@ public class UserActivitySelectService {
 
     private final ActivityRepository activityRepository;
 
+    private final FinishActivityAutoService finishActivityAutoService;
+
     public UserActivitySelectResponse userActivitySelect(Member member, UserActivitySelectRequest userActivitySelectRequest) {
         validateRequest(userActivitySelectRequest);
         Activity activity = Activity.create(member.getId(), null, userActivitySelectRequest.spareTime(), userActivitySelectRequest.type(), userActivitySelectRequest.keyword(), userActivitySelectRequest.title(), userActivitySelectRequest.content(), userActivitySelectRequest.location());
         Activity savedActivity = activityRepository.save(activity);
+        finishActivityAutoService.finishActivityAuto(savedActivity);
         return new UserActivitySelectResponse(savedActivity.getId(), savedActivity.getTitle(), savedActivity.getKeyword());
     }
 

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/entity/ActivityJpaEntity.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/entity/ActivityJpaEntity.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import spring.backend.activity.domain.value.Keyword;
 import spring.backend.activity.domain.value.Type;
+import spring.backend.activity.exception.ActivityErrorCode;
 import spring.backend.core.infrastructure.jpa.shared.BaseLongIdEntity;
 
 import java.time.LocalDateTime;
@@ -42,4 +43,17 @@ public class ActivityJpaEntity extends BaseLongIdEntity {
     private LocalDateTime finishedAt;
 
     private Integer savedTime;
+
+    public boolean isFinished() {
+        return finished != null && finished;
+    }
+
+    public void finish() {
+        if (isFinished()) {
+            throw ActivityErrorCode.ALREADY_FINISHED_ACTIVITY.toException();
+        }
+        finished = true;
+        finishedAt = LocalDateTime.now();
+        savedTime = spareTime;
+    }
 }

--- a/src/main/java/spring/backend/activity/infrastructure/queue/FinishActivityMessage.java
+++ b/src/main/java/spring/backend/activity/infrastructure/queue/FinishActivityMessage.java
@@ -1,0 +1,10 @@
+package spring.backend.activity.infrastructure.queue;
+
+import lombok.Builder;
+
+@Builder
+public record FinishActivityMessage(
+        long activityId,
+        int spareTime
+) {
+}

--- a/src/main/java/spring/backend/activity/infrastructure/queue/FinishActivityMessageConsumer.java
+++ b/src/main/java/spring/backend/activity/infrastructure/queue/FinishActivityMessageConsumer.java
@@ -1,0 +1,35 @@
+package spring.backend.activity.infrastructure.queue;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import spring.backend.activity.exception.ActivityErrorCode;
+import spring.backend.activity.infrastructure.persistence.jpa.entity.ActivityJpaEntity;
+import spring.backend.activity.infrastructure.persistence.jpa.repository.ActivityJpaRepository;
+import spring.backend.core.infrastructure.queue.MessageConsumer;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+@Log4j2
+public class FinishActivityMessageConsumer implements MessageConsumer<FinishActivityMessage> {
+
+    private final ActivityJpaRepository activityJpaRepository;
+
+    @Override
+    @RabbitListener(queues = "${finish-activity-queue.queue}")
+    public void consumeMessage(FinishActivityMessage message) {
+        try {
+            if (message == null) {
+                log.error("[FinishActivityMessageConsumer] Message is null");
+                return;
+            }
+            ActivityJpaEntity activity = activityJpaRepository.findById(message.activityId()).orElseThrow(ActivityErrorCode.NOT_EXIST_ACTIVITY::toException);
+            activity.finish();
+        } catch (Exception e) {
+            log.error("[FinishActivityMessageConsumer] Error processing message", e);
+        }
+    }
+}

--- a/src/main/java/spring/backend/activity/infrastructure/queue/FinishActivityMessageProducer.java
+++ b/src/main/java/spring/backend/activity/infrastructure/queue/FinishActivityMessageProducer.java
@@ -1,0 +1,11 @@
+package spring.backend.activity.infrastructure.queue;
+
+import spring.backend.core.configuration.property.queue.FinishActivityQueueProperty;
+import spring.backend.core.infrastructure.queue.MessageProducer;
+
+public class FinishActivityMessageProducer extends MessageProducer<FinishActivityQueueProperty, FinishActivityMessage> {
+
+    public FinishActivityMessageProducer(FinishActivityQueueProperty queueProperty, FinishActivityMessage message) {
+        super(queueProperty, message);
+    }
+}

--- a/src/main/java/spring/backend/auth/infrastructure/google/GoogleOAuthRestClient.java
+++ b/src/main/java/spring/backend/auth/infrastructure/google/GoogleOAuthRestClient.java
@@ -12,7 +12,7 @@ import spring.backend.auth.dto.response.OAuthAccessTokenResponse;
 import spring.backend.auth.dto.response.OAuthResourceResponse;
 import spring.backend.auth.exception.AuthenticationErrorCode;
 import spring.backend.auth.infrastructure.OAuthRestClient;
-import spring.backend.core.configuration.property.GoogleOAuthProperty;
+import spring.backend.core.configuration.property.oauth.GoogleOAuthProperty;
 
 import java.net.URI;
 

--- a/src/main/java/spring/backend/auth/infrastructure/kakao/KakaoOAuthRestClient.java
+++ b/src/main/java/spring/backend/auth/infrastructure/kakao/KakaoOAuthRestClient.java
@@ -13,7 +13,7 @@ import spring.backend.auth.dto.response.OAuthResourceResponse;
 import spring.backend.auth.exception.AuthenticationErrorCode;
 import spring.backend.auth.infrastructure.OAuthRestClient;
 import spring.backend.auth.infrastructure.kakao.dto.KakaoResourceResponse;
-import spring.backend.core.configuration.property.KakaoOAuthProperty;
+import spring.backend.core.configuration.property.oauth.KakaoOAuthProperty;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;

--- a/src/main/java/spring/backend/auth/infrastructure/naver/NaverOAuthRestClient.java
+++ b/src/main/java/spring/backend/auth/infrastructure/naver/NaverOAuthRestClient.java
@@ -13,7 +13,7 @@ import spring.backend.auth.dto.response.OAuthResourceResponse;
 import spring.backend.auth.exception.AuthenticationErrorCode;
 import spring.backend.auth.infrastructure.OAuthRestClient;
 import spring.backend.auth.infrastructure.naver.dto.NaverResourceResponse;
-import spring.backend.core.configuration.property.NaverOAuthProperty;
+import spring.backend.core.configuration.property.oauth.NaverOAuthProperty;
 
 import java.math.BigInteger;
 import java.net.URI;

--- a/src/main/java/spring/backend/core/configuration/ApplicationContextProvider.java
+++ b/src/main/java/spring/backend/core/configuration/ApplicationContextProvider.java
@@ -1,0 +1,21 @@
+package spring.backend.core.configuration;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApplicationContextProvider implements ApplicationContextAware {
+
+    private static ApplicationContext applicationContext;
+
+    public static <T> T getBean(String name, Class<T> requiredType) {
+        return applicationContext.getBean(name, requiredType);
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        ApplicationContextProvider.applicationContext = applicationContext;
+    }
+}

--- a/src/main/java/spring/backend/core/configuration/RabbitMQConfiguration.java
+++ b/src/main/java/spring/backend/core/configuration/RabbitMQConfiguration.java
@@ -1,0 +1,71 @@
+package spring.backend.core.configuration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.CustomExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.boot.autoconfigure.amqp.RabbitProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import spring.backend.core.configuration.property.queue.FinishActivityQueueProperty;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class RabbitMQConfiguration {
+
+    private final RabbitProperties rabbitProperties;
+
+    private final FinishActivityQueueProperty finishActivityQueueProperty;
+
+    @Bean
+    RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(new Jackson2JsonMessageConverter());
+        return rabbitTemplate;
+    }
+
+    @Bean
+    public MessageConverter rabbitMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public ConnectionFactory rabbitConnectionFactory() {
+        CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
+        connectionFactory.setHost(rabbitProperties.getHost());
+        connectionFactory.setPort(rabbitProperties.getPort());
+        connectionFactory.setUsername(rabbitProperties.getUsername());
+        connectionFactory.setPassword(rabbitProperties.getPassword());
+        connectionFactory.setCacheMode(CachingConnectionFactory.CacheMode.CHANNEL);
+        return connectionFactory;
+    }
+
+    @Bean
+    public CustomExchange finishActivityExchange() {
+        Map<String, Object> args = new HashMap<>();
+        args.put("x-delayed-type", "direct");
+        return new CustomExchange(finishActivityQueueProperty.getExchange(), "x-delayed-message", true, false, args);
+    }
+
+    @Bean
+    Queue finishActivityQueue() {
+        return new Queue(finishActivityQueueProperty.getQueue(), false);
+    }
+
+    @Bean
+    Binding bindingFinishActivityQueue(CustomExchange finishActivityExchange) {
+        return BindingBuilder.bind(finishActivityQueue())
+                .to(finishActivityExchange)
+                .with(finishActivityQueueProperty.getRoutingKey())
+                .noargs();
+    }
+}

--- a/src/main/java/spring/backend/core/configuration/property/oauth/GoogleOAuthProperty.java
+++ b/src/main/java/spring/backend/core/configuration/property/oauth/GoogleOAuthProperty.java
@@ -1,10 +1,10 @@
-package spring.backend.core.configuration.property;
+package spring.backend.core.configuration.property.oauth;
 
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
-import spring.backend.core.configuration.property.shared.BaseOAuthProperty;
+import spring.backend.core.configuration.property.oauth.shared.BaseOAuthProperty;
 
 @Component
 @Getter

--- a/src/main/java/spring/backend/core/configuration/property/oauth/KakaoOAuthProperty.java
+++ b/src/main/java/spring/backend/core/configuration/property/oauth/KakaoOAuthProperty.java
@@ -1,10 +1,10 @@
-package spring.backend.core.configuration.property;
+package spring.backend.core.configuration.property.oauth;
 
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
-import spring.backend.core.configuration.property.shared.BaseOAuthProperty;
+import spring.backend.core.configuration.property.oauth.shared.BaseOAuthProperty;
 
 @Component
 @Getter

--- a/src/main/java/spring/backend/core/configuration/property/oauth/NaverOAuthProperty.java
+++ b/src/main/java/spring/backend/core/configuration/property/oauth/NaverOAuthProperty.java
@@ -1,10 +1,10 @@
-package spring.backend.core.configuration.property;
+package spring.backend.core.configuration.property.oauth;
 
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
-import spring.backend.core.configuration.property.shared.BaseOAuthProperty;
+import spring.backend.core.configuration.property.oauth.shared.BaseOAuthProperty;
 
 @Component
 @Getter

--- a/src/main/java/spring/backend/core/configuration/property/oauth/shared/BaseOAuthProperty.java
+++ b/src/main/java/spring/backend/core/configuration/property/oauth/shared/BaseOAuthProperty.java
@@ -1,4 +1,4 @@
-package spring.backend.core.configuration.property.shared;
+package spring.backend.core.configuration.property.oauth.shared;
 
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/spring/backend/core/configuration/property/queue/FinishActivityQueueProperty.java
+++ b/src/main/java/spring/backend/core/configuration/property/queue/FinishActivityQueueProperty.java
@@ -1,0 +1,10 @@
+package spring.backend.core.configuration.property.queue;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import spring.backend.core.configuration.property.queue.shared.BaseQueueProperty;
+
+@Component
+@ConfigurationProperties("finish-activity-queue")
+public class FinishActivityQueueProperty extends BaseQueueProperty {
+}

--- a/src/main/java/spring/backend/core/configuration/property/queue/shared/BaseQueueProperty.java
+++ b/src/main/java/spring/backend/core/configuration/property/queue/shared/BaseQueueProperty.java
@@ -1,0 +1,15 @@
+package spring.backend.core.configuration.property.queue.shared;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BaseQueueProperty {
+
+    protected String exchange;
+
+    protected String queue;
+
+    protected String routingKey;
+}

--- a/src/main/java/spring/backend/core/infrastructure/queue/MessageConsumer.java
+++ b/src/main/java/spring/backend/core/infrastructure/queue/MessageConsumer.java
@@ -1,0 +1,6 @@
+package spring.backend.core.infrastructure.queue;
+
+public interface MessageConsumer<T> {
+
+    void consumeMessage(T message);
+}

--- a/src/main/java/spring/backend/core/infrastructure/queue/MessageProducer.java
+++ b/src/main/java/spring/backend/core/infrastructure/queue/MessageProducer.java
@@ -1,0 +1,42 @@
+package spring.backend.core.infrastructure.queue;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import spring.backend.core.configuration.ApplicationContextProvider;
+import spring.backend.core.configuration.property.queue.shared.BaseQueueProperty;
+
+@RequiredArgsConstructor
+@Log4j2
+public abstract class MessageProducer<T extends BaseQueueProperty, R> {
+
+    private static final RabbitTemplate rabbitTemplate = ApplicationContextProvider.getBean("rabbitTemplate", RabbitTemplate.class);
+
+    protected final T queueProperty;
+
+    protected final R message;
+
+    public void publishMessage() {
+        try {
+            rabbitTemplate.convertAndSend(queueProperty.getExchange(), queueProperty.getRoutingKey(), message);
+        } catch (Exception e) {
+            log.error("[MessagePublisher] - publishMessage Failed", e);
+        }
+    }
+
+    public void publishMessageWithDelay(long delayTime) {
+        try {
+            rabbitTemplate.convertAndSend(
+                    queueProperty.getExchange(),
+                    queueProperty.getRoutingKey(),
+                    message,
+                    messagePostProcessor -> {
+                        messagePostProcessor.getMessageProperties().setDelayLong(delayTime);
+                        return messagePostProcessor;
+                    }
+            );
+        } catch (Exception e) {
+            log.error("[MessagePublisher] - publishMessageWithDelay Failed", e);
+        }
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- RabbitMQ를 이용해 사용자의 자투리 시간이 지났을 때 메시지 큐를 이용해 비동기로 자동 종료하는 작업입니다.
- Delay Queue Plugin을 설치하여 자투리 시간 만큼 지연 시간을 두고 처리하게 하였습니다.
- application.yml에 RabbitMQ 및 큐 관련 설정 추가되었습니다.

### 성공 응답
![스크린샷 2024-11-15 오전 9 06 38](https://github.com/user-attachments/assets/4bce7f6b-0594-4bfe-b7a3-32032a83cc1c)
![스크린샷 2024-11-15 오전 9 07 00](https://github.com/user-attachments/assets/44371c72-8932-43e7-9918-87fe8084cad3)

### 성공 영상

https://github.com/user-attachments/assets/7a8302e1-d634-4ac2-a862-b5239405becf

---

## ✏️ 관련 이슈
- Resolves : #78 

---

## 🎸 기타 사항 or 추가 코멘트
- 'docker-compose.yml' 에서 docker-compose로 배포환경에 띄워야하는데 내가 함부로 수정하면 안될 거 같아서 docker-compose만 수정하고 이외 env, application.yml(서버 배포용)은 아직 수정하지 않았습니다.. 형이 인프라 신이니까 내가 수정해도 괜찮을지 확인해주면 좋을 거 같아용