### PR TITLE
Feat: (#90) 활동 캘린더를 조회할 수 있다

### DIFF
--- a/src/main/java/spring/backend/activity/dto/request/ReadActivityCalendarRequest.java
+++ b/src/main/java/spring/backend/activity/dto/request/ReadActivityCalendarRequest.java
@@ -1,0 +1,18 @@
+package spring.backend.activity.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+public record ReadActivityCalendarRequest(
+
+        @Min(value = 2024, message = "년도는 2024년 이상이어야 합니다.")
+        @Schema(description = "캘린더 조회 년도", example = "2024")
+        int year,
+
+        @Min(value = 1, message = "월은 1~12 사이여야 합니다.")
+        @Max(value = 12, message = "월은 1~12 사이여야 합니다.")
+        @Schema(description = "캘린더 조회 월", example = "11")
+        int month
+) {
+}

--- a/src/main/java/spring/backend/activity/dto/response/ActivityCalendarResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/ActivityCalendarResponse.java
@@ -1,11 +1,17 @@
 package spring.backend.activity.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record ActivityCalendarResponse(
 
+        @Schema(description = "사용자의 월별 활동 요약",
+                example = "{ \"registrationDate\": \"2024-11-14T06:10:55.091954\", \"totalSavedTime\": 120, \"monthlyActivityCount\": 10 }")
         UserMonthlyActivitySummary summary,
 
+        @Schema(description = "사용자의 월별 활동 상세 정보 리스트",
+                example = "{ \"category\": \"SELF_DEVELOPMENT\", \"title\": \"마음의 편안을 가져다주는 명상음악 20분 듣기\", \"savedTime\": 20, \"activityCreatedAt\": \"2024-11-16T14:24:08.548712\" }")
         List<UserMonthlyActivityDetail> monthlyActivities
 ) {
     public static ActivityCalendarResponse of(UserMonthlyActivitySummary summary, List<UserMonthlyActivityDetail> details) {

--- a/src/main/java/spring/backend/activity/dto/response/ActivityCalendarResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/ActivityCalendarResponse.java
@@ -1,0 +1,14 @@
+package spring.backend.activity.dto.response;
+
+import java.util.List;
+
+public record ActivityCalendarResponse(
+
+        UserMonthlyActivitySummary summary,
+
+        List<UserMonthlyActivityDetail> monthlyActivities
+) {
+    public static ActivityCalendarResponse of(UserMonthlyActivitySummary summary, List<UserMonthlyActivityDetail> details) {
+        return new ActivityCalendarResponse(summary, details);
+    }
+}

--- a/src/main/java/spring/backend/activity/dto/response/UserMonthlyActivityDetail.java
+++ b/src/main/java/spring/backend/activity/dto/response/UserMonthlyActivityDetail.java
@@ -1,0 +1,17 @@
+package spring.backend.activity.dto.response;
+
+import spring.backend.activity.domain.value.Keyword.Category;
+
+import java.time.LocalDateTime;
+
+public record UserMonthlyActivityDetail(
+
+        Category category,
+
+        String title,
+
+        int savedTime,
+
+        LocalDateTime activityCreatedAt
+) {
+}

--- a/src/main/java/spring/backend/activity/dto/response/UserMonthlyActivityDetail.java
+++ b/src/main/java/spring/backend/activity/dto/response/UserMonthlyActivityDetail.java
@@ -1,17 +1,23 @@
 package spring.backend.activity.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import spring.backend.activity.domain.value.Keyword.Category;
 
 import java.time.LocalDateTime;
 
 public record UserMonthlyActivityDetail(
 
+        @Schema(description = "활동 카테고리 \n\n SELF_DEVELOPMENT(자기개발), HEALTH(건강), NATURE(자연), CULTURE_ART(문화/예술), ENTERTAINMENT(엔터테인먼트), RELAXATION(휴식), SOCIAL(소셜)",
+                example = "SELF_DEVELOPMENT")
         Category category,
 
+        @Schema(description = "활동 제목", example = "마음의 편안을 가져다주는 명상음악 20분 듣기")
         String title,
 
+        @Schema(description = "모은 시간", example = "20")
         int savedTime,
 
+        @Schema(description = "활동 생성 시간", example = "2024-11-16T14:24:08.548712")
         LocalDateTime activityCreatedAt
 ) {
 }

--- a/src/main/java/spring/backend/activity/dto/response/UserMonthlyActivitySummary.java
+++ b/src/main/java/spring/backend/activity/dto/response/UserMonthlyActivitySummary.java
@@ -1,0 +1,13 @@
+package spring.backend.activity.dto.response;
+
+import java.time.LocalDateTime;
+
+public record UserMonthlyActivitySummary(
+
+        LocalDateTime registrationDate,
+
+        long totalSavedTime,
+
+        long monthlyActivityCount
+) {
+}

--- a/src/main/java/spring/backend/activity/dto/response/UserMonthlyActivitySummary.java
+++ b/src/main/java/spring/backend/activity/dto/response/UserMonthlyActivitySummary.java
@@ -1,13 +1,18 @@
 package spring.backend.activity.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDateTime;
 
 public record UserMonthlyActivitySummary(
 
+        @Schema(description = "사용자 최초 가입 시간", example = "2024-11-14T06:10:55.091954")
         LocalDateTime registrationDate,
 
+        @Schema(description = "해당 달에 모은 시간 조각의 합 (분 단위)", example = "120")
         long totalSavedTime,
 
+        @Schema(description = "사용자가 해당 달에 한 활동의 총 횟수", example = "10")
         long monthlyActivityCount
 ) {
 }

--- a/src/main/java/spring/backend/activity/presentation/ReadActivityCalendarController.java
+++ b/src/main/java/spring/backend/activity/presentation/ReadActivityCalendarController.java
@@ -1,0 +1,34 @@
+package spring.backend.activity.presentation;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import spring.backend.activity.dto.request.ReadActivityCalendarRequest;
+import spring.backend.activity.dto.response.ActivityCalendarResponse;
+import spring.backend.activity.dto.response.UserMonthlyActivityDetail;
+import spring.backend.activity.dto.response.UserMonthlyActivitySummary;
+import spring.backend.activity.presentation.swagger.ReadActivityCalendarSwagger;
+import spring.backend.activity.query.dao.ActivityDao;
+import spring.backend.core.configuration.argumentresolver.AuthorizedMember;
+import spring.backend.core.configuration.interceptor.Authorization;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.member.domain.entity.Member;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ReadActivityCalendarController implements ReadActivityCalendarSwagger {
+
+    private final ActivityDao activityDao;
+
+    @Authorization
+    @GetMapping("/v1/activity-calendar")
+    public ResponseEntity<RestResponse<ActivityCalendarResponse>> readActivityCalendar(@AuthorizedMember Member member, @Valid ReadActivityCalendarRequest request) {
+        UserMonthlyActivitySummary summary = activityDao.findActivitySummaryByYearAndMonth(member.getId(), request.year(), request.month());
+        List<UserMonthlyActivityDetail> details = activityDao.findActivityDetailsByYearAndMonth(member.getId(), request.year(), request.month());
+        return ResponseEntity.ok(new RestResponse<>(ActivityCalendarResponse.of(summary, details)));
+    }
+}

--- a/src/main/java/spring/backend/activity/presentation/swagger/ReadActivityCalendarSwagger.java
+++ b/src/main/java/spring/backend/activity/presentation/swagger/ReadActivityCalendarSwagger.java
@@ -1,0 +1,26 @@
+package spring.backend.activity.presentation.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import spring.backend.activity.dto.request.ReadActivityCalendarRequest;
+import spring.backend.activity.dto.response.ActivityCalendarResponse;
+import spring.backend.activity.exception.ActivityErrorCode;
+import spring.backend.core.configuration.swagger.ApiErrorCode;
+import spring.backend.core.exception.error.GlobalErrorCode;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.member.domain.entity.Member;
+
+@Tag(name = "Activity", description = "활동")
+public interface ReadActivityCalendarSwagger {
+
+    @Operation(
+            summary = "활동 캘린더 조회 API",
+            description = "사용자가 연월을 선택하여 월별 활동 요약과 월별 활동 상세 정보 리스트를 반환합니다.",
+            operationId = "/v1/activity-calendar"
+    )
+    @ApiErrorCode({GlobalErrorCode.class, ActivityErrorCode.class})
+    ResponseEntity<RestResponse<ActivityCalendarResponse>> readActivityCalendar(@Parameter(hidden = true) Member member, @ParameterObject ReadActivityCalendarRequest request);
+}

--- a/src/main/java/spring/backend/activity/query/dao/ActivityDao.java
+++ b/src/main/java/spring/backend/activity/query/dao/ActivityDao.java
@@ -1,6 +1,8 @@
 package spring.backend.activity.query.dao;
 
 import spring.backend.activity.dto.response.HomeActivityInfoResponse;
+import spring.backend.activity.dto.response.UserMonthlyActivityDetail;
+import spring.backend.activity.dto.response.UserMonthlyActivitySummary;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -9,4 +11,8 @@ import java.util.UUID;
 public interface ActivityDao {
 
     List<HomeActivityInfoResponse> findTodayActivities(UUID memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+
+    UserMonthlyActivitySummary findActivitySummaryByYearAndMonth(UUID memberId, int year, int month);
+
+    List<UserMonthlyActivityDetail> findActivityDetailsByYearAndMonth(UUID memberId, int year, int month);
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 활동 캘린더 조회 API를 구현했습니다.

### 프론트와 논의 결과 ([논의 쓰레드](https://meetup-c.slack.com/archives/C07N89FRW1M/p1731747519399189?thread_ts=1731523747.966539&cid=C07N89FRW1M))
- 달력 API는 1개 
  - 프론트에서 달력 설정 및 리스트(달력 클릭 시 필터링까지)까지 처리
- 회원 가입 기간은 매번 보내기
- 활동 내역 리스트는 최신순으로 보내주기

### 성공 응답
![스크린샷 2024-11-17 오전 4 58 50](https://github.com/user-attachments/assets/2bb17298-a597-4280-98a0-edd1c852d20c)


### 실패 응답
1. 년도가 2024년 이전일 경우
![스크린샷 2024-11-17 오전 5 01 26](https://github.com/user-attachments/assets/6200a0c0-8432-4dad-8615-fd3818badeef)


3. 월이 1 미만 12 초과일 경우
- 1 미만일 경우
![스크린샷 2024-11-17 오전 5 02 31](https://github.com/user-attachments/assets/3a79ac0e-c7af-4783-bca9-94c73ae6555d)

- 12 초과일 경우
![스크린샷 2024-11-17 오전 5 01 38](https://github.com/user-attachments/assets/3d9d9a30-8cd2-4365-a31d-67457aa89f3a)


---

## ✏️ 관련 이슈
- Resolves : #90 

---

## 🎸 기타 사항 or 추가 코멘트