### PR TITLE
Fix: (#103) 활동 자동 종료 서비스를 테스트코드에서 Mock 처리한다

### DIFF
--- a/src/test/java/spring/backend/activity/application/QuickStartActivitySelectServiceTest.java
+++ b/src/test/java/spring/backend/activity/application/QuickStartActivitySelectServiceTest.java
@@ -42,6 +42,9 @@ public class QuickStartActivitySelectServiceTest {
     @Mock
     private QuickStartRepository quickStartRepository;
 
+    @Mock
+    private FinishActivityAutoService finishActivityAutoService;
+
     private Member member;
     private QuickStartActivitySelectRequest quickStartActivitySelectRequest;
     private final Long quickStartId = 1L;

--- a/src/test/java/spring/backend/activity/application/UserActivitySelectServiceTest.java
+++ b/src/test/java/spring/backend/activity/application/UserActivitySelectServiceTest.java
@@ -32,6 +32,9 @@ public class UserActivitySelectServiceTest {
     @Mock
     private ActivityRepository activityRepository;
 
+    @Mock
+    private FinishActivityAutoService finishActivityAutoService;
+
     private Member member;
     private UserActivitySelectRequest userActivitySelectRequest;
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
활동 저장 서비스 테스트코드에서 Mock 객체로 주입하지 않아 null로 처리되는 문제를 확인했습니다.
활동 저장 서비스 테스트에 활동 자동 종료 서비스를 Mock 객체 처리해주었습니다. 

### 빠른 시작으로 활동 저장
![스크린샷 2024-11-18 오후 6 03 41](https://github.com/user-attachments/assets/6dca8d0f-66af-4be2-aa97-b316b8b9b32e)
### 일반 시작으로 활동 저장
![스크린샷 2024-11-18 오후 6 03 51](https://github.com/user-attachments/assets/238e5a78-ccc6-4456-9462-467e46b049ac)
### JWT Test
![스크린샷 2024-11-18 오후 6 11 25](https://github.com/user-attachments/assets/2d70f533-15ad-4c08-9f93-85307fd499aa)
### RotateAccess Test
![스크린샷 2024-11-18 오후 6 11 52](https://github.com/user-attachments/assets/52142625-311c-4a17-b9cc-654f6095246f)
### GetRecommendationsFromClovaService Test
![스크린샷 2024-11-18 오후 6 12 14](https://github.com/user-attachments/assets/0c8ea28c-a6b6-48c8-8630-2364302d7f79)


---

## ✏️ 관련 이슈
- Fixes : #78 

---

## 🎸 기타 사항 or 추가 코멘트