### PR TITLE
Feat: (#109) 15분 주기로 빠른시작 이메일 알림을 전송한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,10 @@ dependencies {
 	// Rabbit MQ
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 	testImplementation 'org.springframework.amqp:spring-rabbit-test'
+
+	// Spring Batch
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
+	testImplementation 'org.springframework.batch:spring-batch-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/spring/backend/BackendApplication.java
+++ b/src/main/java/spring/backend/BackendApplication.java
@@ -3,7 +3,9 @@ package spring.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {

--- a/src/main/java/spring/backend/activity/application/SendQuickStartEmailsScheduler.java
+++ b/src/main/java/spring/backend/activity/application/SendQuickStartEmailsScheduler.java
@@ -1,0 +1,68 @@
+package spring.backend.activity.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import spring.backend.activity.domain.entity.QuickStart;
+import spring.backend.activity.domain.repository.QuickStartRepository;
+import spring.backend.core.util.email.EmailUtil;
+import spring.backend.core.util.email.dto.request.SendEmailRequest;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.repository.MemberRepository;
+
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class SendQuickStartEmailsScheduler {
+
+    private final QuickStartRepository quickStartRepository;
+
+    private final MemberRepository memberRepository;
+
+    private final EmailUtil emailUtil;
+
+    @Scheduled(cron = "0 0/15 * * * ?")
+    public void sendQuickStartEmails() {
+        List<String> receivers = new ArrayList<>();
+
+        final int TIME_INTERVAL_MINUTES = 15;
+        LocalTime now = LocalTime.now();
+        LocalTime lowerBound = now.plusMinutes(1).withSecond(0).withNano(0);
+        LocalTime upperBound = lowerBound.plusMinutes(TIME_INTERVAL_MINUTES - 1);
+
+        log.info("[SendQuickStartEmailsScheduler] Searching for QuickStarts between {} and {}", lowerBound, upperBound);
+
+        List<QuickStart> quickStarts = quickStartRepository.findQuickStartsWithinTimeRange(lowerBound, upperBound);
+
+        quickStarts.stream()
+                .map(QuickStart::getMemberId)
+                .map(memberRepository::findById)
+                .filter(Objects::nonNull)
+                .map(Member::getEmail)
+                .filter(Objects::nonNull)
+                .forEach(receivers::add);
+
+        if (!receivers.isEmpty()) {
+            SendEmailRequest request = SendEmailRequest.builder()
+                    .title("Test Title")
+                    .content("Test Content")
+                    .receivers(receivers.toArray(new String[0]))
+                    .build();
+
+            try {
+                emailUtil.send(request);
+                log.info("[SendQuickStartEmailsScheduler] Successfully sent email to {} receivers", receivers.size());
+            } catch (Exception e) {
+                log.error("[SendQuickStartEmailsScheduler] Failed to send email to {} receivers", receivers.size(), e);
+            }
+        } else {
+            log.warn("[SendQuickStartEmailsScheduler] No valid receivers found in the time range: {} - {}", lowerBound, upperBound);
+        }
+    }
+}

--- a/src/main/java/spring/backend/activity/domain/repository/QuickStartRepository.java
+++ b/src/main/java/spring/backend/activity/domain/repository/QuickStartRepository.java
@@ -2,8 +2,12 @@ package spring.backend.activity.domain.repository;
 
 import spring.backend.activity.domain.entity.QuickStart;
 
+import java.time.LocalTime;
+import java.util.List;
+
 public interface QuickStartRepository {
 
     QuickStart findById(Long id);
     QuickStart save(QuickStart quickStart);
+    List<QuickStart> findQuickStartsWithinTimeRange(LocalTime lowerBound, LocalTime upperBound);
 }

--- a/src/main/java/spring/backend/activity/infrastructure/batch/job/SendQuickStartEmailsJob.java
+++ b/src/main/java/spring/backend/activity/infrastructure/batch/job/SendQuickStartEmailsJob.java
@@ -1,0 +1,117 @@
+package spring.backend.activity.infrastructure.batch.job;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import spring.backend.activity.infrastructure.persistence.jpa.entity.QuickStartJpaEntity;
+import spring.backend.activity.infrastructure.persistence.jpa.repository.QuickStartJpaRepository;
+import spring.backend.core.util.email.EmailUtil;
+import spring.backend.core.util.email.dto.request.SendEmailRequest;
+import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
+import spring.backend.member.infrastructure.persistence.jpa.repository.MemberJpaRepository;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+@Configuration
+@RequiredArgsConstructor
+@Log4j2
+public class SendQuickStartEmailsJob {
+
+    private final JobRepository jobRepository;
+
+    private final JobLauncher jobLauncher;
+
+    private final PlatformTransactionManager platformTransactionManager;
+
+    private final QuickStartJpaRepository quickStartJpaRepository;
+
+    private final MemberJpaRepository memberJpaRepository;
+
+    private final EmailUtil emailUtil;
+
+//    @Scheduled(cron = "0 0/15 * * * ?")
+    public void sendQuickStartEmailsJobScheduler() {
+        try {
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addDate("time", new Date())
+                    .toJobParameters();
+            jobLauncher.run(sendQuickStartEmailsJob(), jobParameters);
+        }  catch (Exception e) {
+            log.error("[SendQuickStartEmailsJob] Scheduler encountered an error at {}", LocalDateTime.now(), e);
+        }
+    }
+
+    public Job sendQuickStartEmailsJob() {
+        final String JOB_NAME = "sendQuickStartEmailsJob";
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .start(sendQuickStartEmailsStep())
+                .build();
+    }
+
+    public Step sendQuickStartEmailsStep() {
+        final String STEP_NAME = "sendQuickStartEmailsStep";
+        return new StepBuilder(STEP_NAME, jobRepository)
+                .tasklet(sendQuickStartEmailsTasklet(), platformTransactionManager)
+                .build();
+    }
+
+    public Tasklet sendQuickStartEmailsTasklet() {
+        return (contribution, chunkContext) -> {
+            List<String> receivers = new ArrayList<>();
+            try {
+                final int TIME_INTERVAL_MINUTES = 15;
+                LocalTime now = LocalTime.now();
+                LocalTime lowerBound = now.plusMinutes(1).withSecond(0).withNano(0);
+                LocalTime upperBound = lowerBound.plusMinutes(TIME_INTERVAL_MINUTES - 1);
+
+                log.info("[SendQuickStartEmailsJob] Searching for QuickStarts between {} and {}", lowerBound, upperBound);
+
+                List<QuickStartJpaEntity> quickStarts = quickStartJpaRepository.findQuickStartsWithinTimeRange(lowerBound, upperBound);
+
+                quickStarts.stream()
+                        .map(QuickStartJpaEntity::getMemberId)
+                        .map(memberJpaRepository::findById)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .map(MemberJpaEntity::getEmail)
+                        .forEach(receivers::add);
+
+                if (!receivers.isEmpty()) {
+                    SendEmailRequest request = SendEmailRequest.builder()
+                            .title("Test Title")
+                            .content("Test Content")
+                            .receivers(receivers.toArray(new String[0]))
+                            .build();
+
+                    try {
+                        emailUtil.send(request);
+                        log.info("[SendQuickStartEmailsJob] Successfully sent email to {} receivers", receivers.size());
+                    } catch (Exception e) {
+                        log.error("[SendQuickStartEmailsJob] Failed to send email to {} receivers", receivers.size(), e);
+                    }
+                } else {
+                    log.warn("[SendQuickStartEmailsJob] No valid receivers found in the time range: {} - {}", lowerBound, upperBound);
+                }
+            } catch (Exception e) {
+                log.error("[SendQuickStartEmailsJob] Error during tasklet execution", e);
+            }
+            return RepeatStatus.FINISHED;
+        };
+    }
+}

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/adapter/QuickStartRepositoryImpl.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/adapter/QuickStartRepositoryImpl.java
@@ -10,6 +10,12 @@ import spring.backend.activity.infrastructure.mapper.QuickStartMapper;
 import spring.backend.activity.infrastructure.persistence.jpa.entity.QuickStartJpaEntity;
 import spring.backend.activity.infrastructure.persistence.jpa.repository.QuickStartJpaRepository;
 
+import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 @Repository
 @RequiredArgsConstructor
 @Log4j2
@@ -37,5 +43,15 @@ public class QuickStartRepositoryImpl implements QuickStartRepository {
             log.error("[QuickStartRepositoryImpl] Failed to save quickStart", e);
             throw QuickStartErrorCode.QUICK_START_SAVE_FAILED.toException();
         }
+    }
+
+    @Override
+    public List<QuickStart> findQuickStartsWithinTimeRange(LocalTime lowerBound, LocalTime upperBound) {
+        List<QuickStartJpaEntity> quickStartJpaEntities = quickStartJpaRepository.findQuickStartsWithinTimeRange(lowerBound, upperBound);
+        return Optional.ofNullable(quickStartJpaEntities)
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(quickStartMapper::toDomainEntity)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/repository/QuickStartJpaRepository.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/repository/QuickStartJpaRepository.java
@@ -1,7 +1,24 @@
 package spring.backend.activity.infrastructure.persistence.jpa.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import spring.backend.activity.infrastructure.persistence.jpa.entity.QuickStartJpaEntity;
 
+import java.time.LocalTime;
+import java.util.List;
+
 public interface QuickStartJpaRepository extends JpaRepository<QuickStartJpaEntity, Long> {
+
+    @Query("""
+        select q
+        from QuickStartJpaEntity q
+        where q.startTime between :lowerBound and :upperBound
+        and q.id in (
+            select min(q2.id)
+            from QuickStartJpaEntity q2
+            where q2.memberId = q.memberId
+            group by q2.memberId
+        )
+    """)
+    List<QuickStartJpaEntity> findQuickStartsWithinTimeRange(LocalTime lowerBound, LocalTime upperBound);
 }

--- a/src/main/java/spring/backend/core/util/email/EmailUtil.java
+++ b/src/main/java/spring/backend/core/util/email/EmailUtil.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import spring.backend.core.util.email.dto.request.SendEmailRequest;
 import spring.backend.core.util.email.exception.MailErrorCode;
 
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 @Component
@@ -29,13 +30,13 @@ public class EmailUtil {
         try {
             SimpleMailMessage message = new SimpleMailMessage();
             message.setFrom(sender);
-            message.setTo(sendEmailRequest.receiver());
+            message.setTo(sendEmailRequest.receivers());
             message.setSubject(sendEmailRequest.title());
             message.setText(sendEmailRequest.content());
             mailSender.send(message);
         } catch (MailParseException e) {
             log.error("[EmailUtil] Failed to parse email for recipient: {}, subject: {}. Error: {}",
-                    sendEmailRequest.receiver(), sendEmailRequest.title(), e.getMessage());
+                    Arrays.toString(sendEmailRequest.receivers()), sendEmailRequest.title(), e.getMessage());
             throw MailErrorCode.FAILED_TO_PARSE_MAIL.toException();
         } catch (MailAuthenticationException e) {
             log.error("[EmailUtil] Authentication failed for email sender: {}. Error: {}",
@@ -43,11 +44,11 @@ public class EmailUtil {
             throw MailErrorCode.AUTHENTICATION_FAILED.toException();
         } catch (MailSendException e) {
             log.error("[EmailUtil] Error occurred while sending email to recipient: {}, subject: {}. Error: {}",
-                    sendEmailRequest.receiver(), sendEmailRequest.title(), e.getMessage());
+                    Arrays.toString(sendEmailRequest.receivers()), sendEmailRequest.title(), e.getMessage());
             throw MailErrorCode.ERROR_OCCURRED_SENDING_MAIL.toException();
         } catch (MailException e) {
             log.error("[EmailUtil] General mail error for recipient: {}, subject: {}. Error: {}",
-                    sendEmailRequest.receiver(), sendEmailRequest.title(), e.getMessage());
+                    Arrays.toString(sendEmailRequest.receivers()), sendEmailRequest.title(), e.getMessage());
             throw MailErrorCode.GENERAL_MAIL_ERROR.toException();
         }
     }
@@ -59,8 +60,8 @@ public class EmailUtil {
     }
 
     private void validateEmailAddress(SendEmailRequest request) {
-        if (request.receiver() == null || !EMAIL_PATTERN.matcher(request.receiver()).matches()) {
-            log.error("[EmailUtil] Invalid email address format: {}", request.receiver());
+        if (request.receivers() == null || Arrays.stream(request.receivers()).anyMatch(email -> !EMAIL_PATTERN.matcher(email).matches())) {
+            log.error("[EmailUtil] Invalid email address format: {}", Arrays.toString(request.receivers()));
             throw MailErrorCode.INVALID_MAIL_ADDRESS.toException();
         }
     }

--- a/src/main/java/spring/backend/core/util/email/dto/request/SendEmailRequest.java
+++ b/src/main/java/spring/backend/core/util/email/dto/request/SendEmailRequest.java
@@ -1,7 +1,10 @@
 package spring.backend.core.util.email.dto.request;
 
+import lombok.Builder;
+
+@Builder
 public record SendEmailRequest(
-        String receiver,
+        String[] receivers,
         String title,
         String content
 ) {


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 15분 주기로 이메일 전송하는 로직을 구현하였습니다.
- 기존 메일 로직은 메일 주소에 하나의 메일을 보내지만, 메일 주소 1개씩 보내다 보니 SMTP 세션 연결, 연결 해지가 반복되어 시간이 무수히 많이 걸림을 알게 되었습니다. 따라서 이 부분은 메일 주소를 여러개 모아 한 번에 보내는 벌크 형식으로 변경하였습니다.
- 처음에 Spring Batch를 이용해서 대용량 작업에 맞게 진행하였으나, Spring Batch를 사용해서 15분 주기로 메일을 전송하는게 과연 옳은가? 라는 생각이 들었고 모니터링이나 롤백시킬 수 있다는 점은 좋지만 단순 이메일 전송이기에 오버 엔지니어링이라 생각이 들었습니다.
- 그래서 단순 스케쥴러로도 구현을 해놓은 상태입니다.
- Spring Batch와 단순 스케쥴러는 처리 속도는 동일합니다. 지금은 단순 스케쥴러를 활성화해놓은 상태이지만, 추후 모니터링 환경에서 Spring Batch와 단순 스케쥴러의 CPU 점유나 리소스 소모 등 여러 조건을 확인하고 어떤걸 사용할지 선택하면 좋을 거 같아 코드는 제거하지 않았습니다.

[3명의 사용자에게 보내는 과정]
#### 하나씩 보낼 때 소모 시간
![tasklet, request 1](https://github.com/user-attachments/assets/29bb2f7d-6966-420c-a81c-621d4c4aa572)

#### 벌크로 보낼 때 소모 시간 (배치)
![tasklet, receivers 여러명 보낼 때](https://github.com/user-attachments/assets/26eaf012-03c0-4555-a1ee-7c47a21f6189)

#### 벌크로 보낼 때 소모 시간 (단순 스케쥴러)
![스크린샷 2024-11-22 오전 6 13 33](https://github.com/user-attachments/assets/8c1d63eb-8482-4f72-b784-e12d6de450f9)

스케쥴러는 4초라고 뜨지만 나노세컨드를 무시한 계산이라 배치와 유사한 시간이라고 보시면 될 거 같습니다!

#### 스케쥴러 동작 예시

12시일 때, 12시 1분 ~ 15분의 빠른 시작을 찾아 연결된 사용자에게 전송합니다. 
이때 메일은 1회만 발송됩니다. (기획 측에 문의 넣은 상태)
(만약 빠른 시작이 여러개인 한 사용자가 있을 경우, 여러 개의 메일이 가는건 비효율적이라 생각 -> 기획 측에 문의 넣었고 문의 결과는 PR에 업데이트 하겠습니다!)

---

## ✏️ 관련 이슈
- Resolves : #109 

---

## 🎸 기타 사항 or 추가 코멘트
- 메일 제목과 본문 내용은 기획 측에서 전달해주신다고 하셔서 전달 오면 추가해서 올리고 노티드릴게요~!