### PR TITLE
Refactor: (#110) AccessToken을 Cookie로 반환한다.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Cnergy Backend CI/CD
 on:
   push:
     branches: [dev]
-  pull_request:
-    branches: [dev]
 
 jobs:
   ci:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Cnergy Backend CI/CD
 on:
   push:
     branches: [dev]
+  pull_request:
+    branches: [dev]
 
 jobs:
   ci:

--- a/src/main/java/spring/backend/activity/dto/response/ActivityWithTitleAndSavedTimeResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/ActivityWithTitleAndSavedTimeResponse.java
@@ -9,7 +9,7 @@ public record ActivityWithTitleAndSavedTimeResponse(
         String title,
 
         @Schema(description = "모은 시간", example = "60")
-        int savedTime,
+        long savedTime,
 
         @Schema(description = "활동 날짜", example = "2021-07-01T00:00:00")
         LocalDateTime dateOfActivity

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/dao/ActivityJpaDao.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/dao/ActivityJpaDao.java
@@ -98,7 +98,7 @@ public interface ActivityJpaDao extends JpaRepository<ActivityJpaEntity, Long>, 
     @Query("""
                 select new spring.backend.activity.dto.response.ActivityWithTitleAndSavedTimeResponse(
                     a.title,
-                    a.savedTime,
+                    coalesce(sum(a.savedTime), 0),
                     a.createdAt
                 )
                 from ActivityJpaEntity a

--- a/src/main/java/spring/backend/auth/application/HandleOAuthLoginService.java
+++ b/src/main/java/spring/backend/auth/application/HandleOAuthLoginService.java
@@ -49,7 +49,6 @@ public class HandleOAuthLoginService {
         CreateMemberWithOAuthRequest createMemberWithOAuthRequest = CreateMemberWithOAuthRequest.builder()
                 .provider(provider)
                 .email(oAuthResourceResponse.getEmail())
-                .nickname(oAuthResourceResponse.getName())
                 .build();
 
         Member member = createMemberWithOAuthService.createMemberWithOAuth(createMemberWithOAuthRequest);

--- a/src/main/java/spring/backend/auth/application/HandleOAuthLoginService.java
+++ b/src/main/java/spring/backend/auth/application/HandleOAuthLoginService.java
@@ -3,17 +3,17 @@ package spring.backend.auth.application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
-import spring.backend.auth.presentation.dto.response.LoginResponse;
-import spring.backend.auth.presentation.dto.response.OAuthAccessTokenResponse;
-import spring.backend.auth.presentation.dto.response.OAuthResourceResponse;
 import spring.backend.auth.exception.AuthenticationErrorCode;
 import spring.backend.auth.infrastructure.OAuthRestClient;
 import spring.backend.auth.infrastructure.OAuthRestClientFactory;
-import spring.backend.member.domain.service.CreateMemberWithOAuthService;
+import spring.backend.auth.presentation.dto.response.LoginResponse;
+import spring.backend.auth.presentation.dto.response.OAuthAccessTokenResponse;
+import spring.backend.auth.presentation.dto.response.OAuthResourceResponse;
+import spring.backend.core.application.JwtService;
 import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.service.CreateMemberWithOAuthService;
 import spring.backend.member.domain.value.Provider;
 import spring.backend.member.presentation.dto.request.CreateMemberWithOAuthRequest;
-import spring.backend.core.application.JwtService;
 
 @Service
 @RequiredArgsConstructor
@@ -54,6 +54,6 @@ public class HandleOAuthLoginService {
 
         Member member = createMemberWithOAuthService.createMemberWithOAuth(createMemberWithOAuthRequest);
         refreshTokenService.saveRefreshToken(member);
-        return new LoginResponse(jwtService.provideAccessToken(member),  member.getRole());
+        return LoginResponse.of(jwtService.provideAccessToken(member), jwtService.provideRefreshToken(member), member);
     }
 }

--- a/src/main/java/spring/backend/auth/application/HandleOAuthLoginService.java
+++ b/src/main/java/spring/backend/auth/application/HandleOAuthLoginService.java
@@ -49,9 +49,11 @@ public class HandleOAuthLoginService {
         CreateMemberWithOAuthRequest createMemberWithOAuthRequest = CreateMemberWithOAuthRequest.builder()
                 .provider(provider)
                 .email(oAuthResourceResponse.getEmail())
+                .nickname(oAuthResourceResponse.getName())
                 .build();
 
         Member member = createMemberWithOAuthService.createMemberWithOAuth(createMemberWithOAuthRequest);
-        return LoginResponse.of(jwtService.provideAccessToken(member), refreshTokenService.saveRefreshToken(member), member);
+        refreshTokenService.saveRefreshToken(member);
+        return new LoginResponse(jwtService.provideAccessToken(member),  member.getRole());
     }
 }

--- a/src/main/java/spring/backend/auth/application/RefreshTokenService.java
+++ b/src/main/java/spring/backend/auth/application/RefreshTokenService.java
@@ -38,6 +38,7 @@ public class RefreshTokenService {
             throw AuthenticationErrorCode.NOT_EXIST_REFRESH_TOKEN.toException();
         }
 
+        jwtService.getPayload(refreshToken);
         return refreshToken;
     }
 

--- a/src/main/java/spring/backend/auth/application/RefreshTokenService.java
+++ b/src/main/java/spring/backend/auth/application/RefreshTokenService.java
@@ -9,7 +9,6 @@ import spring.backend.core.application.JwtService;
 import spring.backend.member.domain.entity.Member;
 
 import java.time.temporal.ChronoUnit;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -26,30 +25,25 @@ public class RefreshTokenService {
     }
 
     public String saveRefreshToken(Member member) {
-        refreshTokenRepository.save(member.getId(), jwtService.provideRefreshToken(member), REFRESH_TOKEN_EXPIRATION, convertChronoUnitToTimeUnit(ChronoUnit.DAYS));
-        return getRefreshToken(member.getId());
-    }
-
-    public String getRefreshToken(UUID memberId) {
-        String refreshToken = refreshTokenRepository.findByMemberId(memberId);
-
-        if (refreshToken == null || refreshToken.isEmpty()) {
-            log.error("리프레시 토큰이 저장소에 존재하지 않습니다.");
-            throw AuthenticationErrorCode.NOT_EXIST_REFRESH_TOKEN.toException();
-        }
-
-        jwtService.getPayload(refreshToken);
+        String refreshToken = jwtService.provideRefreshToken(member);
+        refreshTokenRepository.save(refreshToken, member.getId(), REFRESH_TOKEN_EXPIRATION, convertChronoUnitToTimeUnit(ChronoUnit.DAYS));
         return refreshToken;
     }
 
-    public void deleteRefreshToken(UUID memberId) {
-
-        if (refreshTokenRepository.findByMemberId(memberId) == null) {
-            log.error("memberId에 해당하는 리프레시 토큰이 저장소에 존재하지 않습니다.");
+    public void validateRefreshToken(String refreshToken) {
+        String savedRefreshToken = refreshTokenRepository.findByRefreshToken(refreshToken);
+        if (savedRefreshToken == null || savedRefreshToken.isEmpty()) {
             throw AuthenticationErrorCode.NOT_EXIST_REFRESH_TOKEN.toException();
         }
+        jwtService.getPayload(refreshToken);
+    }
 
-        refreshTokenRepository.deleteByMemberId(memberId);
+    public void deleteRefreshToken(String refreshToken) {
+        if (refreshTokenRepository.findByRefreshToken(refreshToken) == null) {
+            log.error("리프레시 토큰이 저장소에 존재하지 않습니다.");
+            throw AuthenticationErrorCode.NOT_EXIST_REFRESH_TOKEN.toException();
+        }
+        refreshTokenRepository.deleteByRefreshToken(refreshToken);
     }
 
     private TimeUnit convertChronoUnitToTimeUnit(ChronoUnit chronoUnit) {

--- a/src/main/java/spring/backend/auth/application/RotateAccessTokenService.java
+++ b/src/main/java/spring/backend/auth/application/RotateAccessTokenService.java
@@ -3,8 +3,9 @@ package spring.backend.auth.application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
-import spring.backend.auth.presentation.dto.response.RotateAccessTokenResponse;
 import spring.backend.auth.exception.AuthenticationErrorCode;
+import spring.backend.auth.infrastructure.redis.repository.RefreshTokenRedisRepository;
+import spring.backend.auth.presentation.dto.response.RotateAccessTokenResponse;
 import spring.backend.core.application.JwtService;
 import spring.backend.member.domain.entity.Member;
 import spring.backend.member.domain.repository.MemberRepository;
@@ -20,29 +21,15 @@ public class RotateAccessTokenService {
     private final MemberRepository memberRepository;
     private final JwtService jwtService;
     private final RefreshTokenService refreshTokenService;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
-    public RotateAccessTokenResponse rotateAccessToken(String invalidAccessToken) {
-        UUID memberIdFromInvalidAccessToken = jwtService.extractMemberIdFromExpiredAccessToken(invalidAccessToken);
-        String refreshToken = refreshTokenService.getRefreshToken(memberIdFromInvalidAccessToken);
-        UUID memberId = extractMemberIdFromRefreshToken(refreshToken);
-        validateRefreshToken(memberId, refreshToken);
-        Member member = memberRepository.findById(memberId);
-        return new RotateAccessTokenResponse(jwtService.provideAccessToken(Optional.ofNullable(member).orElseThrow(MemberErrorCode.NOT_EXIST_MEMBER::toException)));
-    }
-
-    private UUID extractMemberIdFromRefreshToken(String refreshToken) {
-        if (refreshToken == null) {
-            log.error("쿠키에 refreshToken이 존재하지 않습니다.");
+    public RotateAccessTokenResponse rotateAccessToken(String refreshToken) {
+        if(refreshToken == null) {
             throw AuthenticationErrorCode.MISSING_COOKIE_VALUE.toException();
         }
-        return UUID.fromString(jwtService.getPayload(refreshToken).get("memberId", String.class));
-    }
-
-    private void validateRefreshToken(UUID memberId, String refreshToken) {
-        String savedRefreshToken = refreshTokenService.getRefreshToken(memberId);
-        if (!savedRefreshToken.equals(refreshToken)) {
-            log.error("리프레시 토큰이 저장소에 존재하지 않습니다.");
-            throw AuthenticationErrorCode.NOT_EXIST_REFRESH_TOKEN.toException();
-        }
+        refreshTokenService.validateRefreshToken(refreshToken);
+        UUID memberId = UUID.fromString(refreshTokenRedisRepository.findByRefreshToken(refreshToken));
+        Member member = memberRepository.findById(memberId);
+        return new RotateAccessTokenResponse(jwtService.provideAccessToken(Optional.ofNullable(member).orElseThrow(MemberErrorCode.NOT_EXIST_MEMBER::toException)));
     }
 }

--- a/src/main/java/spring/backend/auth/application/RotateAccessTokenService.java
+++ b/src/main/java/spring/backend/auth/application/RotateAccessTokenService.java
@@ -1,7 +1,7 @@
 package spring.backend.auth.application;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import spring.backend.auth.presentation.dto.response.RotateAccessTokenResponse;
 import spring.backend.auth.exception.AuthenticationErrorCode;
@@ -15,13 +15,15 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
+@Log4j2
 public class RotateAccessTokenService {
     private final MemberRepository memberRepository;
     private final JwtService jwtService;
     private final RefreshTokenService refreshTokenService;
 
-    public RotateAccessTokenResponse rotateAccessToken(String refreshToken) {
+    public RotateAccessTokenResponse rotateAccessToken(String invalidAccessToken) {
+        UUID memberIdFromInvalidAccessToken = jwtService.extractMemberIdFromExpiredAccessToken(invalidAccessToken);
+        String refreshToken = refreshTokenService.getRefreshToken(memberIdFromInvalidAccessToken);
         UUID memberId = extractMemberIdFromRefreshToken(refreshToken);
         validateRefreshToken(memberId, refreshToken);
         Member member = memberRepository.findById(memberId);

--- a/src/main/java/spring/backend/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/spring/backend/auth/domain/repository/RefreshTokenRepository.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public interface RefreshTokenRepository {
-    void save(String refreshToken,UUID memberId, Long expireTime, TimeUnit timeUnit);
+    void save(String refreshToken, UUID memberId, Long expireTime, TimeUnit timeUnit);
     String findByRefreshToken(String refreshToken);
     void deleteByRefreshToken(String refreshToken);
 }

--- a/src/main/java/spring/backend/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/spring/backend/auth/domain/repository/RefreshTokenRepository.java
@@ -4,7 +4,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public interface RefreshTokenRepository {
-    void save(UUID memberId, String refreshToken, Long expireTime, TimeUnit timeUnit);
-    String findByMemberId(UUID memberId);
-    void deleteByMemberId(UUID memberId);
+    void save(String refreshToken,UUID memberId, Long expireTime, TimeUnit timeUnit);
+    String findByRefreshToken(String refreshToken);
+    void deleteByRefreshToken(String refreshToken);
 }

--- a/src/main/java/spring/backend/auth/dto/response/LoginResponse.java
+++ b/src/main/java/spring/backend/auth/dto/response/LoginResponse.java
@@ -1,0 +1,6 @@
+package spring.backend.auth.dto.response;
+
+import spring.backend.member.domain.value.Role;
+
+public record LoginResponse(String accessToken, Role role) {
+}

--- a/src/main/java/spring/backend/auth/dto/response/LoginResponse.java
+++ b/src/main/java/spring/backend/auth/dto/response/LoginResponse.java
@@ -1,6 +1,0 @@
-package spring.backend.auth.dto.response;
-
-import spring.backend.member.domain.value.Role;
-
-public record LoginResponse(String accessToken, Role role) {
-}

--- a/src/main/java/spring/backend/auth/exception/AuthenticationErrorCode.java
+++ b/src/main/java/spring/backend/auth/exception/AuthenticationErrorCode.java
@@ -11,7 +11,7 @@ import spring.backend.core.exception.error.BaseErrorCode;
 public enum AuthenticationErrorCode implements BaseErrorCode<DomainException> {
 
     NOT_EXIST_HEADER(HttpStatus.UNAUTHORIZED, "Authorization Header가 존재하지 않습니다."),
-    NOT_EXIST_TOKEN(HttpStatus.UNAUTHORIZED, "Authorization Header에 Token이 존재하지 않습니다."),
+    NOT_EXIST_TOKEN(HttpStatus.UNAUTHORIZED, "쿠키에 Token이 존재하지 않습니다."),
     NOT_MATCH_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "토큰의 형식이 맞지 않습니다."),
     INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "토큰의 서명이 올바르지 않습니다."),
     NOT_DEFINE_TOKEN(HttpStatus.UNAUTHORIZED, "정의되지 않은 토큰입니다."),
@@ -28,7 +28,8 @@ public enum AuthenticationErrorCode implements BaseErrorCode<DomainException> {
     MISSING_COOKIE_VALUE(HttpStatus.BAD_REQUEST, "쿠키값이 존재하지 않습니다."),
     INVALID_MEMBER_SIGN_UP_CONDITION(HttpStatus.BAD_REQUEST, "회원가입을 위한 사용자 조건이 유효하지 않습니다."),
     NOT_EXIST_SIGN_UP_CONDITION(HttpStatus.BAD_REQUEST, "회원가입 요청이 유효하지 않습니다."),
-    INVALID_BIRTH_YEAR(HttpStatus.BAD_REQUEST, "출생년도는 현재 연도와 100년 전 사이여야 합니다.");
+    INVALID_BIRTH_YEAR(HttpStatus.BAD_REQUEST, "출생년도는 현재 연도와 100년 전 사이여야 합니다."),
+    FAILED_TO_EXTRACT_MEMBER_ID_FROM_EXPIRED_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "만료된 액세스 토큰에서 회원 ID를 추출하는데 실패했습니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/spring/backend/auth/exception/AuthenticationErrorCode.java
+++ b/src/main/java/spring/backend/auth/exception/AuthenticationErrorCode.java
@@ -11,7 +11,7 @@ import spring.backend.core.exception.error.BaseErrorCode;
 public enum AuthenticationErrorCode implements BaseErrorCode<DomainException> {
 
     NOT_EXIST_HEADER(HttpStatus.UNAUTHORIZED, "Authorization Header가 존재하지 않습니다."),
-    NOT_EXIST_TOKEN(HttpStatus.UNAUTHORIZED, "쿠키에 Token이 존재하지 않습니다."),
+    NOT_EXIST_TOKEN_In_COOKIE(HttpStatus.UNAUTHORIZED, "쿠키에 Token이 존재하지 않습니다."),
     NOT_MATCH_TOKEN_FORMAT(HttpStatus.UNAUTHORIZED, "토큰의 형식이 맞지 않습니다."),
     INVALID_SIGNATURE(HttpStatus.UNAUTHORIZED, "토큰의 서명이 올바르지 않습니다."),
     NOT_DEFINE_TOKEN(HttpStatus.UNAUTHORIZED, "정의되지 않은 토큰입니다."),

--- a/src/main/java/spring/backend/auth/exception/AuthenticationErrorCode.java
+++ b/src/main/java/spring/backend/auth/exception/AuthenticationErrorCode.java
@@ -24,7 +24,7 @@ public enum AuthenticationErrorCode implements BaseErrorCode<DomainException> {
     RESOURCE_SERVER_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "OAuth Resource Server에 접근할 수 없습니다."),
     UNSUPPORTED_REDIS_TIME_TYPE(HttpStatus.BAD_REQUEST, "Redis 만료시간은 ChronoUnit 타입이어야 합니다."),
     MISMATCH_TOKEN_MEMBER(HttpStatus.UNAUTHORIZED, "토큰의 회원 ID와 요청한 회원 ID가 일치하지 않습니다."),
-    NOT_EXIST_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레시 토큰이 저장소에 존재하지 않습니다."),
+    NOT_EXIST_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 저장소에 존재하지 않습니다."),
     MISSING_COOKIE_VALUE(HttpStatus.BAD_REQUEST, "쿠키값이 존재하지 않습니다."),
     INVALID_MEMBER_SIGN_UP_CONDITION(HttpStatus.BAD_REQUEST, "회원가입을 위한 사용자 조건이 유효하지 않습니다."),
     NOT_EXIST_SIGN_UP_CONDITION(HttpStatus.BAD_REQUEST, "회원가입 요청이 유효하지 않습니다."),

--- a/src/main/java/spring/backend/auth/infrastructure/redis/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/spring/backend/auth/infrastructure/redis/repository/RefreshTokenRedisRepository.java
@@ -19,10 +19,10 @@ public class RefreshTokenRedisRepository implements RefreshTokenRepository {
     private final RedisTemplate<String, String> redisTemplate;
 
     @Override
-    public void save(UUID memberId, String refreshToken, Long expireTime, TimeUnit timeUnit) {
+    public void save(String refreshToken, UUID memberId, Long expireTime, TimeUnit timeUnit) {
         try {
             ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-            valueOperations.set(memberId.toString(), refreshToken, expireTime, timeUnit);
+            valueOperations.set(refreshToken, memberId.toString(), expireTime, timeUnit);
         } catch (RedisConnectionException e) {
             log.error("Redis 연결 오류 : {}", e.getMessage());
             throw GlobalErrorCode.REDIS_CONNECTION_ERROR.toException();
@@ -32,23 +32,22 @@ public class RefreshTokenRedisRepository implements RefreshTokenRepository {
     }
 
     @Override
-    public String findByMemberId(UUID memberId) {
+    public String findByRefreshToken(String refreshToken) {
         try {
             ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-            return valueOperations.get(memberId.toString());
+            return valueOperations.get(refreshToken);
         } catch (RedisConnectionException e) {
             log.error("Redis 연결 오류 : {}", e.getMessage());
             throw GlobalErrorCode.REDIS_CONNECTION_ERROR.toException();
         } catch (Exception e) {
             throw GlobalErrorCode.INTERNAL_ERROR.toException();
         }
-
     }
 
     @Override
-    public void deleteByMemberId(UUID memberId) {
+    public void deleteByRefreshToken(String refreshToken) {
         try {
-            redisTemplate.delete(memberId.toString());
+            redisTemplate.delete(refreshToken);
         } catch (RedisConnectionException e) {
             log.error("Redis 연결 오류 : {}", e.getMessage());
             throw GlobalErrorCode.REDIS_CONNECTION_ERROR.toException();

--- a/src/main/java/spring/backend/auth/presentation/HandleOAuthLoginController.java
+++ b/src/main/java/spring/backend/auth/presentation/HandleOAuthLoginController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.*;
 import spring.backend.auth.application.HandleOAuthLoginService;
 import spring.backend.auth.presentation.dto.response.LoginResponse;
 import spring.backend.core.presentation.RestResponse;
-import spring.backend.auth.dto.response.LoginResponse;
 
 @RestController
 @RequestMapping("/v1/oauth/login")
@@ -21,17 +20,22 @@ public class HandleOAuthLoginController {
     public ResponseEntity<?> handleOAuthLogin(@RequestParam(value = "code", required = false) String code,
                                               @RequestParam(value = "state", required = false) String state, @PathVariable String providerName) {
         LoginResponse loginResponse = handleOAuthLoginService.handleOAuthLogin(providerName, code, state);
+        // Todo: 배포 시 httpOnly(true)로 변경
         ResponseCookie accessTokenCookie = ResponseCookie.from("access_token", loginResponse.accessToken())
-                .httpOnly(true)
+                .httpOnly(false)
+                .path("/")
                 .build();
-
-        ResponseCookie roleCookie = ResponseCookie.from("user_role", loginResponse.role().toString())
-                .httpOnly(true)
+        // Todo: 배포 시 httpOnly(true)로 변경
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", loginResponse.refreshToken())
+                .httpOnly(false)
+                .path("/")
                 .build();
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
-                .header(HttpHeaders.SET_COOKIE, roleCookie.toString())
-                .build();
+                .headers(header -> {
+                    header.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
+                    header.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+                })
+                .body(new RestResponse<>(loginResponse.userInfo()));
     }
 }

--- a/src/main/java/spring/backend/auth/presentation/HandleOAuthLoginController.java
+++ b/src/main/java/spring/backend/auth/presentation/HandleOAuthLoginController.java
@@ -1,11 +1,14 @@
 package spring.backend.auth.presentation;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import spring.backend.auth.application.HandleOAuthLoginService;
 import spring.backend.auth.presentation.dto.response.LoginResponse;
 import spring.backend.core.presentation.RestResponse;
+import spring.backend.auth.dto.response.LoginResponse;
 
 @RestController
 @RequestMapping("/v1/oauth/login")
@@ -15,10 +18,20 @@ public class HandleOAuthLoginController {
     private final HandleOAuthLoginService handleOAuthLoginService;
 
     @GetMapping("/{providerName}")
-    public ResponseEntity<RestResponse<LoginResponse>> handleOAuthLogin(@RequestParam(value = "code", required = false) String code,
-                                                                        @RequestParam(value = "state", required = false) String state,
-                                                                        @PathVariable String providerName) {
+    public ResponseEntity<?> handleOAuthLogin(@RequestParam(value = "code", required = false) String code,
+                                              @RequestParam(value = "state", required = false) String state, @PathVariable String providerName) {
         LoginResponse loginResponse = handleOAuthLoginService.handleOAuthLogin(providerName, code, state);
-        return ResponseEntity.ok(new RestResponse<>(loginResponse));
+        ResponseCookie accessTokenCookie = ResponseCookie.from("access_token", loginResponse.accessToken())
+                .httpOnly(true)
+                .build();
+
+        ResponseCookie roleCookie = ResponseCookie.from("user_role", loginResponse.role().toString())
+                .httpOnly(true)
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, roleCookie.toString())
+                .build();
     }
 }

--- a/src/main/java/spring/backend/auth/presentation/HandleOAuthLoginController.java
+++ b/src/main/java/spring/backend/auth/presentation/HandleOAuthLoginController.java
@@ -22,12 +22,12 @@ public class HandleOAuthLoginController {
         LoginResponse loginResponse = handleOAuthLoginService.handleOAuthLogin(providerName, code, state);
         // Todo: 배포 시 httpOnly(true)로 변경
         ResponseCookie accessTokenCookie = ResponseCookie.from("access_token", loginResponse.accessToken())
-                .httpOnly(false)
+                .httpOnly(true)
                 .path("/")
                 .build();
         // Todo: 배포 시 httpOnly(true)로 변경
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", loginResponse.refreshToken())
-                .httpOnly(false)
+                .httpOnly(true)
                 .path("/")
                 .build();
 

--- a/src/main/java/spring/backend/auth/presentation/HandleOAuthLoginController.java
+++ b/src/main/java/spring/backend/auth/presentation/HandleOAuthLoginController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import spring.backend.auth.application.HandleOAuthLoginService;
 import spring.backend.auth.presentation.dto.response.LoginResponse;
+import spring.backend.auth.presentation.dto.response.LoginUserInfoResponse;
 import spring.backend.core.presentation.RestResponse;
 
 @RestController
@@ -17,25 +18,25 @@ public class HandleOAuthLoginController {
     private final HandleOAuthLoginService handleOAuthLoginService;
 
     @GetMapping("/{providerName}")
-    public ResponseEntity<?> handleOAuthLogin(@RequestParam(value = "code", required = false) String code,
-                                              @RequestParam(value = "state", required = false) String state, @PathVariable String providerName) {
+    public ResponseEntity<RestResponse<LoginUserInfoResponse>> handleOAuthLogin(@RequestParam(value = "code", required = false) String code,
+                                                                                @RequestParam(value = "state", required = false) String state, @PathVariable String providerName) {
         LoginResponse loginResponse = handleOAuthLoginService.handleOAuthLogin(providerName, code, state);
-        // Todo: 배포 시 httpOnly(true)로 변경
         ResponseCookie accessTokenCookie = ResponseCookie.from("access_token", loginResponse.accessToken())
                 .httpOnly(true)
                 .path("/")
                 .build();
-        // Todo: 배포 시 httpOnly(true)로 변경
         ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", loginResponse.refreshToken())
                 .httpOnly(true)
                 .path("/")
                 .build();
+
+        LoginUserInfoResponse loginUserInfoResponse = LoginUserInfoResponse.from(loginResponse);
 
         return ResponseEntity.ok()
                 .headers(header -> {
                     header.add(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
                     header.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
                 })
-                .body(new RestResponse<>(loginResponse.userInfo()));
+                .body(new RestResponse<>(loginUserInfoResponse));
     }
 }

--- a/src/main/java/spring/backend/auth/presentation/LogoutController.java
+++ b/src/main/java/spring/backend/auth/presentation/LogoutController.java
@@ -9,16 +9,15 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.auth.application.RefreshTokenService;
 import spring.backend.auth.presentation.swagger.LogoutSwagger;
-import spring.backend.core.application.JwtService;
+import spring.backend.core.presentation.RestResponse;
 
 @RestController
 @RequiredArgsConstructor
 public class LogoutController implements LogoutSwagger {
     private final RefreshTokenService refreshTokenService;
-    private final JwtService jwtService;
 
     @PostMapping("/v1/logout")
-    public ResponseEntity<?> logout(
+    public ResponseEntity<RestResponse<Void>> logout(
             @CookieValue(name = "access_token", required = false) String accessToken,
             @CookieValue(name = "refresh_token", required = false) String refreshToken
     ) {

--- a/src/main/java/spring/backend/auth/presentation/LogoutController.java
+++ b/src/main/java/spring/backend/auth/presentation/LogoutController.java
@@ -1,23 +1,15 @@
 package spring.backend.auth.presentation;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.auth.application.RefreshTokenService;
 import spring.backend.auth.presentation.swagger.LogoutSwagger;
 import spring.backend.core.application.JwtService;
-
-import java.util.UUID;
-import spring.backend.auth.presentation.swagger.LogoutSwagger;
-import spring.backend.core.configuration.argumentresolver.AuthorizedMember;
-import spring.backend.core.configuration.interceptor.Authorization;
-import spring.backend.member.domain.entity.Member;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,27 +19,23 @@ public class LogoutController implements LogoutSwagger {
 
     @PostMapping("/v1/logout")
     public ResponseEntity<?> logout(
-            @CookieValue(name = "access_token", required = false) String accessToken
+            @CookieValue(name = "access_token", required = false) String accessToken,
+            @CookieValue(name = "refresh_token", required = false) String refreshToken
     ) {
-
-        UUID memberId = jwtService.extractMemberIdFromExpiredAccessToken(accessToken);
-        refreshTokenService.deleteRefreshToken(memberId);
-
+        refreshTokenService.deleteRefreshToken(refreshToken);
         ResponseCookie accessTokenCookie = ResponseCookie.from("access_token", "")
                 .httpOnly(true)
                 .path("/")
                 .maxAge(0)
                 .build();
-
-        ResponseCookie userRoleCookie = ResponseCookie.from("user_role", "")
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh_token", "")
                 .httpOnly(true)
                 .path("/")
                 .maxAge(0)
                 .build();
-
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
-                .header(HttpHeaders.SET_COOKIE, userRoleCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
                 .build();
     }
 }

--- a/src/main/java/spring/backend/auth/presentation/LogoutController.java
+++ b/src/main/java/spring/backend/auth/presentation/LogoutController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.auth.application.RefreshTokenService;
+import spring.backend.auth.presentation.swagger.LogoutSwagger;
 import spring.backend.core.application.JwtService;
 
 import java.util.UUID;
@@ -20,7 +21,7 @@ import spring.backend.member.domain.entity.Member;
 
 @RestController
 @RequiredArgsConstructor
-public class LogoutController {
+public class LogoutController implements LogoutSwagger {
     private final RefreshTokenService refreshTokenService;
     private final JwtService jwtService;
 

--- a/src/main/java/spring/backend/auth/presentation/LogoutController.java
+++ b/src/main/java/spring/backend/auth/presentation/LogoutController.java
@@ -2,10 +2,17 @@ package spring.backend.auth.presentation;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.auth.application.RefreshTokenService;
+import spring.backend.core.application.JwtService;
+
+import java.util.UUID;
 import spring.backend.auth.presentation.swagger.LogoutSwagger;
 import spring.backend.core.configuration.argumentresolver.AuthorizedMember;
 import spring.backend.core.configuration.interceptor.Authorization;
@@ -13,14 +20,33 @@ import spring.backend.member.domain.entity.Member;
 
 @RestController
 @RequiredArgsConstructor
-public class LogoutController implements LogoutSwagger {
-
+public class LogoutController {
     private final RefreshTokenService refreshTokenService;
+    private final JwtService jwtService;
 
     @PostMapping("/v1/logout")
-    @Authorization
-    @ResponseStatus(HttpStatus.OK)
-    public void logout(@AuthorizedMember Member member) {
-        refreshTokenService.deleteRefreshToken(member.getId());
+    public ResponseEntity<?> logout(
+            @CookieValue(name = "access_token", required = false) String accessToken
+    ) {
+
+        UUID memberId = jwtService.extractMemberIdFromExpiredAccessToken(accessToken);
+        refreshTokenService.deleteRefreshToken(memberId);
+
+        ResponseCookie accessTokenCookie = ResponseCookie.from("access_token", "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        ResponseCookie userRoleCookie = ResponseCookie.from("user_role", "")
+                .httpOnly(true)
+                .path("/")
+                .maxAge(0)
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, accessTokenCookie.toString())
+                .header(HttpHeaders.SET_COOKIE, userRoleCookie.toString())
+                .build();
     }
 }

--- a/src/main/java/spring/backend/auth/presentation/RotateAccessTokenController.java
+++ b/src/main/java/spring/backend/auth/presentation/RotateAccessTokenController.java
@@ -1,9 +1,12 @@
 package spring.backend.auth.presentation;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.auth.application.RotateAccessTokenService;
@@ -13,13 +16,22 @@ import spring.backend.core.presentation.RestResponse;
 @RestController
 @RequestMapping("/v1/token/rotate")
 @RequiredArgsConstructor
+@Log4j2
 public class RotateAccessTokenController {
     private final RotateAccessTokenService rotateTokenService;
 
-    @GetMapping
+    @PostMapping
     public ResponseEntity<RestResponse<RotateAccessTokenResponse>> rotateAccessToken(
-            @CookieValue(name = "refreshToken", required = false) String refreshToken
+            @CookieValue(name = "access_token", required = false) String accessToken
     ) {
-        return ResponseEntity.ok(new RestResponse<>(rotateTokenService.rotateAccessToken(refreshToken)));
+        RotateAccessTokenResponse rotateAccessTokenResponse = rotateTokenService.rotateAccessToken(accessToken);
+        ResponseCookie cookie = ResponseCookie.from("access_token", rotateAccessTokenResponse.accessToken())
+                .httpOnly(true)
+                .path("/")
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .build();
     }
 }

--- a/src/main/java/spring/backend/auth/presentation/RotateAccessTokenController.java
+++ b/src/main/java/spring/backend/auth/presentation/RotateAccessTokenController.java
@@ -10,10 +10,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.auth.application.RotateAccessTokenService;
-import spring.backend.auth.dto.response.RotateAccessTokenResponse;
-import spring.backend.auth.presentation.swagger.RotateAccessTokenSwagger;
 import spring.backend.auth.presentation.dto.response.RotateAccessTokenResponse;
+import spring.backend.auth.presentation.swagger.RotateAccessTokenSwagger;
 import spring.backend.core.presentation.RestResponse;
+
+import static org.springframework.http.ResponseCookie.from;
 
 @RestController
 @RequestMapping("/v1/token/rotate")
@@ -24,16 +25,16 @@ public class RotateAccessTokenController implements RotateAccessTokenSwagger {
 
     @PostMapping
     public ResponseEntity<RestResponse<RotateAccessTokenResponse>> rotateAccessToken(
-            @CookieValue(name = "access_token", required = false) String accessToken
+            @CookieValue(name = "refresh_token", required = false) String refreshToken
     ) {
-        RotateAccessTokenResponse rotateAccessTokenResponse = rotateTokenService.rotateAccessToken(accessToken);
-        ResponseCookie cookie = ResponseCookie.from("access_token", rotateAccessTokenResponse.accessToken())
-                .httpOnly(true)
+        RotateAccessTokenResponse rotateAccessTokenResponse = rotateTokenService.rotateAccessToken(refreshToken);
+        ResponseCookie newAccessToken = from("access_token", rotateAccessTokenResponse.accessToken())
+                .httpOnly(false)
                 .path("/")
                 .build();
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.SET_COOKIE, cookie.toString())
+                .header(HttpHeaders.SET_COOKIE, newAccessToken.toString())
                 .build();
     }
 }

--- a/src/main/java/spring/backend/auth/presentation/RotateAccessTokenController.java
+++ b/src/main/java/spring/backend/auth/presentation/RotateAccessTokenController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.auth.application.RotateAccessTokenService;
+import spring.backend.auth.dto.response.RotateAccessTokenResponse;
+import spring.backend.auth.presentation.swagger.RotateAccessTokenSwagger;
 import spring.backend.auth.presentation.dto.response.RotateAccessTokenResponse;
 import spring.backend.core.presentation.RestResponse;
 
@@ -17,7 +19,7 @@ import spring.backend.core.presentation.RestResponse;
 @RequestMapping("/v1/token/rotate")
 @RequiredArgsConstructor
 @Log4j2
-public class RotateAccessTokenController {
+public class RotateAccessTokenController implements RotateAccessTokenSwagger {
     private final RotateAccessTokenService rotateTokenService;
 
     @PostMapping

--- a/src/main/java/spring/backend/auth/presentation/RotateAccessTokenController.java
+++ b/src/main/java/spring/backend/auth/presentation/RotateAccessTokenController.java
@@ -29,7 +29,7 @@ public class RotateAccessTokenController implements RotateAccessTokenSwagger {
     ) {
         RotateAccessTokenResponse rotateAccessTokenResponse = rotateTokenService.rotateAccessToken(refreshToken);
         ResponseCookie newAccessToken = from("access_token", rotateAccessTokenResponse.accessToken())
-                .httpOnly(false)
+                .httpOnly(true)
                 .path("/")
                 .build();
 

--- a/src/main/java/spring/backend/auth/presentation/dto/response/LoginUserInfoResponse.java
+++ b/src/main/java/spring/backend/auth/presentation/dto/response/LoginUserInfoResponse.java
@@ -1,0 +1,42 @@
+package spring.backend.auth.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import spring.backend.member.domain.value.Gender;
+import spring.backend.member.domain.value.Role;
+
+import java.time.LocalDateTime;
+
+public record LoginUserInfoResponse(
+        @Schema(description = "사용자 유형(MEMBER, GUEST)", example = "MEMBER")
+        Role role,
+
+        @Schema(description = "사용자 이메일", example = "example@example.com")
+        String email,
+
+        @Schema(description = "사용자 닉네임", example = "john_doe")
+        String nickname,
+
+        @Schema(description = "사용자 출생 연도", example = "1990")
+        int birthYear,
+
+        @Schema(description = "사용자 성별 (MALE, FEMALE, NONE)", example = "MALE")
+        Gender gender,
+
+        @Schema(description = "사용자 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String profileImage,
+
+        @Schema(description = "사용자 가입 날짜", example = "2024-11-14T06:10:55.091954")
+        LocalDateTime registrationDate
+) {
+    public static LoginUserInfoResponse from(LoginResponse loginResponse) {
+        return new LoginUserInfoResponse(
+                loginResponse.userInfo().role(),
+                loginResponse.userInfo().email(),
+                loginResponse.userInfo().nickname(),
+                loginResponse.userInfo().birthYear(),
+                loginResponse.userInfo().gender(),
+                loginResponse.userInfo().profileImage(),
+                loginResponse.userInfo().registrationDate()
+                );
+    }
+}

--- a/src/main/java/spring/backend/auth/presentation/swagger/LogoutSwagger.java
+++ b/src/main/java/spring/backend/auth/presentation/swagger/LogoutSwagger.java
@@ -6,8 +6,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import spring.backend.auth.exception.AuthenticationErrorCode;
 import spring.backend.core.configuration.swagger.ApiErrorCode;
-import spring.backend.core.exception.error.GlobalErrorCode;
-import spring.backend.member.domain.entity.Member;
 
 @Tag(name = "Auth", description = "인증/인가")
 public interface LogoutSwagger {
@@ -22,6 +20,8 @@ public interface LogoutSwagger {
     })
     ResponseEntity<?> logout(
             @Parameter(description = "쿠키에 있는 access_token", required = false)
-            String accessToken
+            String accessToken,
+            @Parameter(description = "쿠키에 있는 refresh_token", required = false)
+            String refreshToken
     );
 }

--- a/src/main/java/spring/backend/auth/presentation/swagger/LogoutSwagger.java
+++ b/src/main/java/spring/backend/auth/presentation/swagger/LogoutSwagger.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import spring.backend.auth.exception.AuthenticationErrorCode;
 import spring.backend.core.configuration.swagger.ApiErrorCode;
+import spring.backend.core.exception.error.GlobalErrorCode;
+import spring.backend.core.presentation.RestResponse;
 
 @Tag(name = "Auth", description = "인증/인가")
 public interface LogoutSwagger {
@@ -16,9 +18,9 @@ public interface LogoutSwagger {
             operationId = "/v1/logout"
     )
     @ApiErrorCode({
-            AuthenticationErrorCode.class
+            GlobalErrorCode.class, AuthenticationErrorCode.class
     })
-    ResponseEntity<?> logout(
+    ResponseEntity<RestResponse<Void>> logout(
             @Parameter(description = "쿠키에 있는 access_token", required = false)
             String accessToken,
             @Parameter(description = "쿠키에 있는 refresh_token", required = false)

--- a/src/main/java/spring/backend/auth/presentation/swagger/LogoutSwagger.java
+++ b/src/main/java/spring/backend/auth/presentation/swagger/LogoutSwagger.java
@@ -3,6 +3,7 @@ package spring.backend.auth.presentation.swagger;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
 import spring.backend.auth.exception.AuthenticationErrorCode;
 import spring.backend.core.configuration.swagger.ApiErrorCode;
 import spring.backend.core.exception.error.GlobalErrorCode;
@@ -16,6 +17,11 @@ public interface LogoutSwagger {
             description = "사용자의 로그아웃을 진행합니다. \n\n 로그아웃 시, 사용자의 토큰이 무효화되어, 다시 로그인을 진행해야 합니다.",
             operationId = "/v1/logout"
     )
-    @ApiErrorCode({GlobalErrorCode.class, AuthenticationErrorCode.class})
-    void logout(@Parameter(hidden = true) Member member);
+    @ApiErrorCode({
+            AuthenticationErrorCode.class
+    })
+    ResponseEntity<?> logout(
+            @Parameter(description = "쿠키에 있는 access_token", required = false)
+            String accessToken
+    );
 }

--- a/src/main/java/spring/backend/auth/presentation/swagger/RotateAccessTokenSwagger.java
+++ b/src/main/java/spring/backend/auth/presentation/swagger/RotateAccessTokenSwagger.java
@@ -1,0 +1,25 @@
+package spring.backend.auth.presentation.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import spring.backend.auth.dto.response.RotateAccessTokenResponse;
+import spring.backend.core.configuration.swagger.ApiErrorCode;
+import spring.backend.core.presentation.RestResponse;
+import spring.backend.auth.exception.AuthenticationErrorCode;
+import spring.backend.core.exception.error.GlobalErrorCode;
+
+@Tag(name = "Auth", description = "인증/인가")
+public interface RotateAccessTokenSwagger {
+    @Operation(
+            summary = "토큰 재발급 API",
+            description = "Access Token이 만료된 경우, Refresh Token을 이용하여 새로운 Access Token을 발급합니다",
+            operationId = "/v1/token/rotate"
+    )
+    @ApiErrorCode({GlobalErrorCode.class, AuthenticationErrorCode.class})
+    ResponseEntity<RestResponse<RotateAccessTokenResponse>> rotateAccessToken(
+            @Parameter(description = "쿠키에 있는 만료된 access_token", required = false)
+            String accessToken
+    );
+}

--- a/src/main/java/spring/backend/auth/presentation/swagger/RotateAccessTokenSwagger.java
+++ b/src/main/java/spring/backend/auth/presentation/swagger/RotateAccessTokenSwagger.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import spring.backend.auth.dto.response.RotateAccessTokenResponse;
+import spring.backend.auth.presentation.dto.response.RotateAccessTokenResponse;
 import spring.backend.core.configuration.swagger.ApiErrorCode;
 import spring.backend.core.presentation.RestResponse;
 import spring.backend.auth.exception.AuthenticationErrorCode;
@@ -19,7 +19,7 @@ public interface RotateAccessTokenSwagger {
     )
     @ApiErrorCode({GlobalErrorCode.class, AuthenticationErrorCode.class})
     ResponseEntity<RestResponse<RotateAccessTokenResponse>> rotateAccessToken(
-            @Parameter(description = "쿠키에 있는 만료된 access_token", required = false)
-            String accessToken
+            @Parameter(description = "쿠키에 있는 refresh_token", required = false)
+            String refreshToken
     );
 }

--- a/src/main/java/spring/backend/core/application/JwtService.java
+++ b/src/main/java/spring/backend/core/application/JwtService.java
@@ -98,31 +98,23 @@ public class JwtService {
     }
 
     private String provideToken(String email, UUID id, Type type, long expiration) {
-        Date expiryDate = Date.from(Instant.now().plus(expiration, ChronoUnit.DAYS));
+        Date expiryDate;
+        Map<String, String> claims;
+        if (type.equals(Type.ACCESS)) {
+            expiryDate = Date.from(Instant.now().plus(expiration, ChronoUnit.SECONDS));
+            claims = Map.of(
+                    "memberId", id.toString(),
+                    "email", email,
+                    "type", type.getType());
+        } else {
+            expiryDate = Date.from(Instant.now().plus(expiration, ChronoUnit.DAYS));
+            claims = Map.of();
+        }
         return Jwts.builder()
-                .claims(Map.of(
-                        "memberId", id.toString(),
-                        "email", email,
-                        "type", type.getType()))
+                .claims(claims)
                 .issuedAt(new Date())
                 .expiration(expiryDate)
                 .signWith(SECRET_KEY)
                 .compact();
-    }
-
-    public UUID extractMemberIdFromExpiredAccessToken(String invalidAccessToken) {
-        try {
-            Claims claims = Jwts.parser()
-                    .verifyWith(SECRET_KEY)
-                    .build()
-                    .parseSignedClaims(invalidAccessToken)
-                    .getPayload();
-            return UUID.fromString(claims.get("memberId", String.class));
-        } catch (ExpiredJwtException e) {
-            return UUID.fromString(e.getClaims().get("memberId", String.class));
-        } catch (Exception e) {
-            log.error("Failed to extract userId from invalid token", e);
-            throw AuthenticationErrorCode.FAILED_TO_EXTRACT_MEMBER_ID_FROM_EXPIRED_ACCESS_TOKEN.toException();
-        }
     }
 }

--- a/src/main/java/spring/backend/core/application/JwtService.java
+++ b/src/main/java/spring/backend/core/application/JwtService.java
@@ -100,7 +100,7 @@ public class JwtService {
     private String provideToken(String email, UUID id, Type type, long expiration) {
         Date expiryDate;
         Map<String, String> claims;
-        if (type.equals(Type.ACCESS)) {
+        if (type == Type.ACCESS) {
             expiryDate = Date.from(Instant.now().plus(expiration, ChronoUnit.SECONDS));
             claims = Map.of(
                     "memberId", id.toString(),

--- a/src/main/java/spring/backend/core/configuration/WebMvcConfiguration.java
+++ b/src/main/java/spring/backend/core/configuration/WebMvcConfiguration.java
@@ -25,7 +25,7 @@ public class WebMvcConfiguration implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000", "https://cnergy.kro.kr", "https://cnergy.p-e.kr")
+                .allowedOrigins("http://localhost:3000", "https://cnergy.kro.kr", "https://cnergy.p-e.kr", "http://localhost:5173")
                 .allowedMethods("GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowCredentials(true)
                 .maxAge(3000);

--- a/src/main/java/spring/backend/core/configuration/argumentresolver/LoginMemberArgumentResolver.java
+++ b/src/main/java/spring/backend/core/configuration/argumentresolver/LoginMemberArgumentResolver.java
@@ -1,5 +1,7 @@
 package spring.backend.core.configuration.argumentresolver;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.core.MethodParameter;
@@ -8,12 +10,12 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
-import spring.backend.auth.exception.AuthenticationErrorCode;
 import spring.backend.core.application.JwtService;
 import spring.backend.member.domain.entity.Member;
 import spring.backend.member.domain.repository.MemberRepository;
 import spring.backend.member.exception.MemberErrorCode;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -21,10 +23,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Log4j2
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
-
-    public static final String AUTHORIZATION_HEADER = "Authorization";
-
-    public static final String AUTHORIZATION_BEARER_PREFIX = "Bearer";
 
     private final JwtService jwtService;
 
@@ -37,21 +35,29 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        String authorizationHeader = webRequest.getHeader(AUTHORIZATION_HEADER);
-        String token = extractToken(authorizationHeader);
+        String token = extractToken(webRequest);
+        if (token == null) {
+            log.error("토큰이 존재하지 않습니다.");
+            throw new IllegalArgumentException("토큰이 존재하지 않습니다.");
+        }
+
         UUID memberId = jwtService.extractMemberId(token);
         Member member = memberRepository.findById(memberId);
         return Optional.ofNullable(member).orElseThrow(MemberErrorCode.NOT_EXIST_MEMBER::toException);
     }
 
-    private String extractToken(String authorizationHeader) {
-        if (authorizationHeader == null) {
-            throw AuthenticationErrorCode.NOT_EXIST_HEADER.toException();
+    private String extractToken(NativeWebRequest request) {
+        HttpServletRequest httpRequest = request.getNativeRequest(HttpServletRequest.class);
+        if (httpRequest != null) {
+            Cookie[] cookies = httpRequest.getCookies();
+            if (cookies != null) {
+                return Arrays.stream(cookies)
+                        .filter(cookie -> "access_token".equals(cookie.getName()))
+                        .findFirst()
+                        .map(Cookie::getValue)
+                        .orElse(null);
+            }
         }
-        try {
-            return authorizationHeader.split(AUTHORIZATION_BEARER_PREFIX)[1].replace(" ", "");
-        } catch (Exception e) {
-            throw AuthenticationErrorCode.NOT_EXIST_TOKEN.toException();
-        }
+        return null;
     }
 }

--- a/src/main/java/spring/backend/core/configuration/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/spring/backend/core/configuration/interceptor/AuthorizationInterceptor.java
@@ -10,6 +10,9 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import spring.backend.auth.exception.AuthenticationErrorCode;
 import spring.backend.core.application.JwtService;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 @Log4j2
@@ -17,12 +20,17 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
 
     private final JwtService jwtService;
 
+    private static final List<String> PASS_THROUGH_PATTERNS = Arrays.asList(
+            "/swagger-ui", "/v3/api-docs", "/v1/oauth", "/v1/token/rotate"
+    );
+
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-        if (isOAuthLoginRequest(request)) {
+
+        if (isPassThroughRequest(request.getRequestURI())) {
             return true;
         }
-
         String accessToken = extractToken(request);
         if (accessToken == null) {
             log.error("쿠키에 토큰이 존재하지 않습니다.");
@@ -32,14 +40,15 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
         return true;
     }
 
-    private boolean isOAuthLoginRequest(HttpServletRequest request) {
-        return request.getRequestURI().startsWith("/v1/oauth");
+    private boolean isPassThroughRequest(String uri) {
+        return PASS_THROUGH_PATTERNS.stream().anyMatch(uri::contains);
     }
 
     private String extractToken(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
+                log.info("cookie: {}", cookie);
                 if ("access_token".equals(cookie.getName())) {
                     return cookie.getValue();
                 }

--- a/src/main/java/spring/backend/core/configuration/interceptor/AuthorizationInterceptor.java
+++ b/src/main/java/spring/backend/core/configuration/interceptor/AuthorizationInterceptor.java
@@ -39,7 +39,7 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
         log.info("accessToken: {}", accessToken);
         if (accessToken == null) {
             log.error("쿠키에 토큰이 존재하지 않습니다.");
-            throw AuthenticationErrorCode.NOT_EXIST_TOKEN.toException();
+            throw AuthenticationErrorCode.NOT_EXIST_TOKEN_In_COOKIE.toException();
         }
         jwtService.validateTokenExpiration(accessToken);
         return true;

--- a/src/main/java/spring/backend/core/configuration/swagger/SwaggerConfiguration.java
+++ b/src/main/java/spring/backend/core/configuration/swagger/SwaggerConfiguration.java
@@ -9,12 +9,12 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.examples.Example;
 import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.MediaType;
-import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
-import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,31 +26,19 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @Configuration
-@OpenAPIDefinition(
-        info = @Info(title = "조각조각 API", description = "조각조각 : API 명세서", version = "v1.0.0"),
-        servers = {@Server(url = "${springdoc.server-url}", description = "Https Server URL")}
-)
+@OpenAPIDefinition(info = @Info(title = "조각조각 API", description = "조각조각 : API 명세서", version = "v1.0.0"),
+        servers = {@Server(url = "${springdoc.server-url}", description = "Https Server URL")})
 public class SwaggerConfiguration {
 
   @Bean
-  public OpenAPI openAPI() {
-    SecurityScheme cookieAuth = new SecurityScheme()
-            .type(SecurityScheme.Type.APIKEY)
-            .in(SecurityScheme.In.COOKIE)
-            .name("access_token");
-
-    SecurityRequirement securityRequirement = new SecurityRequirement().addList("cookieAuth");
-
-    Parameter accessTokenParam = new Parameter()
-            .in("cookie")
-            .name("access_token")
-            .schema(new StringSchema())
-            .required(false);
+  public OpenAPI openAPI(){
+    SecurityScheme securityScheme = new SecurityScheme()
+            .type(Type.HTTP).scheme("bearer").bearerFormat("JWT")
+            .in(In.HEADER).name("Authorization");
+    SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
 
     return new OpenAPI()
-            .components(new Components()
-                    .addSecuritySchemes("cookieAuth", cookieAuth)
-                    .addParameters("accessToken", accessTokenParam))
+            .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
             .security(Arrays.asList(securityRequirement));
   }
 

--- a/src/test/java/spring/backend/core/application/RefreshTokenServiceTest.java
+++ b/src/test/java/spring/backend/core/application/RefreshTokenServiceTest.java
@@ -1,6 +1,9 @@
 package spring.backend.core.application;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -8,18 +11,20 @@ import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import spring.backend.auth.application.RefreshTokenService;
-import spring.backend.core.exception.DomainException;
+import spring.backend.auth.infrastructure.redis.repository.RefreshTokenRedisRepository;
 import spring.backend.member.domain.entity.Member;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @SpringBootTest
 public class RefreshTokenServiceTest {
     @Autowired
     private RefreshTokenService refreshTokenService;
+
+    @Autowired
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     private final UUID memberId = UUID.randomUUID();
 
@@ -47,18 +52,12 @@ public class RefreshTokenServiceTest {
         connectionFactory.getConnection().flushDb();
     }
 
-    @DisplayName("RefreshToken이 발급될 때 ID와 RefreshToken를 Redis에 저장된다")
+    @DisplayName("RefreshToken이 발급될 때 RefreshToken과 ID를 Redis에 저장된다")
     @Test
     void saveRefreshTokenWhenTokenReleased() {
-        // when & then
-        assertThat(refreshTokenService.saveRefreshToken(member)).isEqualTo(refreshTokenService.getRefreshToken(memberId));
-    }
-
-    @DisplayName("memberId에 해당하는 RefreshToken이 Redis에 저장되어 있지 않은 경우 에러를 반환한다.")
-    @Test
-    void throwExceptionWhenRefreshTokenIsNotInRedis() {
-        // when & then
-        assertThatThrownBy(() -> refreshTokenService.getRefreshToken(UUID.randomUUID()))
-                .isInstanceOf(DomainException.class).hasMessage("리프레시 토큰이 저장소에 존재하지 않습니다.");
+        // when
+        String refreshToken = refreshTokenService.saveRefreshToken(member);
+        // then
+        assertThat(member.getId().toString()).isEqualTo(refreshTokenRedisRepository.findByRefreshToken(refreshToken));
     }
 }

--- a/src/test/java/spring/backend/core/configuration/argumentresolver/LoginMemberArgumentResolverTest.java
+++ b/src/test/java/spring/backend/core/configuration/argumentresolver/LoginMemberArgumentResolverTest.java
@@ -1,5 +1,7 @@
 package spring.backend.core.configuration.argumentresolver;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -8,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.core.MethodParameter;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import spring.backend.core.application.JwtService;
@@ -50,7 +53,8 @@ public class LoginMemberArgumentResolverTest {
         member = Member.builder()
                 .id(memberId)
                 .build();
-        token = jwtService.provideAccessToken(member);
+        token = "mockToken";
+        when(jwtService.provideAccessToken(any(Member.class))).thenReturn(token);
     }
 
     @DisplayName("LoginMember 어노테이션이 있는 경우 지원한다")
@@ -61,19 +65,43 @@ public class LoginMemberArgumentResolverTest {
         Assertions.assertTrue(loginMemberArgumentResolver.supportsParameter(parameter));
     }
 
-    @DisplayName("Authorization 헤더에 유효한 토큰이 있을 때 Member 객체를 반환한다")
+//    @DisplayName("Authorization 헤더에 유효한 토큰이 있을 때 Member 객체를 반환한다")
+//    @Test
+//    public void returnsMemberObject_whenAuthorizationHeaderIsProvided() throws Exception {
+//        // when
+//        MethodParameter parameter = mock(MethodParameter.class);
+//        when(parameter.hasParameterAnnotation(LoginMember.class)).thenReturn(true);
+//        when(webRequest.getHeader("Authorization")).thenReturn("Bearer " + token);
+//        when(jwtService.extractMemberId(any(String.class))).thenReturn(memberId);
+//        when(memberRepository.findById(memberId)).thenReturn(member);
+//
+//        // then
+//        Object result = loginMemberArgumentResolver.resolveArgument(parameter, mavContainer, webRequest, null);
+//        assertNotNull(result);
+//        assertThat(result).isEqualTo(member);
+//    }
+
+    @DisplayName("쿠키에 유효한 토큰이 있을 때 Member 객체를 반환한다")
     @Test
-    public void returnsMemberObject_whenAuthorizationHeaderIsProvided() throws Exception {
+    public void returnsMemberObject_whenValidTokenInCookie() throws Exception {
+        // given
+        String cookieName = "access_token";
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        System.out.println("token: " + token);
+        System.out.println("member : " + member);
+        mockRequest.setCookies(new Cookie(cookieName, token));
+
         // when
         MethodParameter parameter = mock(MethodParameter.class);
         when(parameter.hasParameterAnnotation(LoginMember.class)).thenReturn(true);
-        when(webRequest.getHeader("Authorization")).thenReturn("Bearer " + token);
-        when(jwtService.extractMemberId(any(String.class))).thenReturn(memberId);
+        when(webRequest.getNativeRequest(HttpServletRequest.class)).thenReturn(mockRequest);
+        when(jwtService.extractMemberId(token)).thenReturn(memberId);
         when(memberRepository.findById(memberId)).thenReturn(member);
 
         // then
         Object result = loginMemberArgumentResolver.resolveArgument(parameter, mavContainer, webRequest, null);
         assertNotNull(result);
-        assertThat(result).isEqualTo(member);
+        assertThat(result).isInstanceOf(Member.class);
+        assertThat(((Member) result).getId()).isEqualTo(memberId);
     }
 }

--- a/src/test/java/spring/backend/core/configuration/argumentresolver/LoginMemberArgumentResolverTest.java
+++ b/src/test/java/spring/backend/core/configuration/argumentresolver/LoginMemberArgumentResolverTest.java
@@ -65,22 +65,6 @@ public class LoginMemberArgumentResolverTest {
         Assertions.assertTrue(loginMemberArgumentResolver.supportsParameter(parameter));
     }
 
-//    @DisplayName("Authorization 헤더에 유효한 토큰이 있을 때 Member 객체를 반환한다")
-//    @Test
-//    public void returnsMemberObject_whenAuthorizationHeaderIsProvided() throws Exception {
-//        // when
-//        MethodParameter parameter = mock(MethodParameter.class);
-//        when(parameter.hasParameterAnnotation(LoginMember.class)).thenReturn(true);
-//        when(webRequest.getHeader("Authorization")).thenReturn("Bearer " + token);
-//        when(jwtService.extractMemberId(any(String.class))).thenReturn(memberId);
-//        when(memberRepository.findById(memberId)).thenReturn(member);
-//
-//        // then
-//        Object result = loginMemberArgumentResolver.resolveArgument(parameter, mavContainer, webRequest, null);
-//        assertNotNull(result);
-//        assertThat(result).isEqualTo(member);
-//    }
-
     @DisplayName("쿠키에 유효한 토큰이 있을 때 Member 객체를 반환한다")
     @Test
     public void returnsMemberObject_whenValidTokenInCookie() throws Exception {


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- 토큰을 쿠키로 전달합니다.
- 스웨거 설정을 변경했습니다. 현재 토큰 인증으로 되어있어, 쿠키로 인증을 변경하니 스웨거 접속이 불가했기에 수정했습니다.
- 로그아웃 엔드포인트를 만들었습니다.

**로그인 시**

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/8eaee3db-bf60-445c-a66d-ebdccab67d1b">

**토큰 재발급**

<img width="1314" alt="스크린샷 2024-11-22 17 00 05" src="https://github.com/user-attachments/assets/f6eaefbc-421e-4cbb-9a8d-5957b28be6d4">
(만료된 토큰으로 요청을 보냈습니다.)

---

## ✏️ 관련 이슈

- Resolves : #110 
---

## 🎸 기타 사항 or 추가 코멘트
- 쿠키 기반 인증의 문제가 있습니다. 