### PR TITLE
Fix: (#120) 수신자를 여러 명으로 처리하도록 SendEmailRequest를 변경하면서 테스트 코드도 수정한다

### DIFF
--- a/src/test/java/spring/backend/core/util/EmailUtilTest.java
+++ b/src/test/java/spring/backend/core/util/EmailUtilTest.java
@@ -4,10 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.mail.javamail.JavaMailSender;
 import spring.backend.core.exception.DomainException;
 import spring.backend.core.util.email.EmailUtil;
 import spring.backend.core.util.email.dto.request.SendEmailRequest;
@@ -27,7 +24,7 @@ public class EmailUtilTest {
     @Test
     void throwExceptionWhenToInRequestIsInvalid() {
         // GIVEN
-        sendEmailRequest = new SendEmailRequest("test", "Test Subject", "Test Content");
+        sendEmailRequest = new SendEmailRequest(new String[]{"test", "test2"}, "Test Subject", "Test Content");
 
         // WHEN & THEN
         DomainException ex = assertThrows(DomainException.class, () -> emailUtil.send(sendEmailRequest), "올바르지 않은 이메일 주소입니다.");
@@ -51,7 +48,7 @@ public class EmailUtilTest {
     @Test
     void throwExceptionWhenSubjectInRequestIsNull() {
         // GIVEN
-        sendEmailRequest = new SendEmailRequest("test@naver.com", "", "Test Content");
+        sendEmailRequest = new SendEmailRequest(new String[]{"test@naver.com", "test2@naver.com"}, "", "Test Content");
 
         // WHEN & THEN
         DomainException ex = assertThrows(DomainException.class, () -> emailUtil.send(sendEmailRequest), "메일 제목이 없습니다.");
@@ -63,7 +60,7 @@ public class EmailUtilTest {
     @Test
     void throwExceptionWhenTextInRequestIsNull() {
         // GIVEN
-        sendEmailRequest = new SendEmailRequest("test@naver.com", "Test Subject", "");
+        sendEmailRequest = new SendEmailRequest(new String[]{"test@naver.com", "test2@naver.com"}, "Test Subject", "");
 
         // WHEN & THEN
         DomainException ex = assertThrows(DomainException.class, () -> emailUtil.send(sendEmailRequest), "메일 내용이 없습니다.");


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- #109 이메일 전송 작업에서 SendEmailRequest의 수신자를 String 배열로 변경하였으나 테스트 코드는 변경되지 못한 이슈 수정 작업입니다.

#### 테스트 전체 성공
![스크린샷 2024-11-23 오전 2 33 13](https://github.com/user-attachments/assets/b9ce14b2-3411-4e40-b85e-e2301324affc)


---

## ✏️ 관련 이슈
- Fixes : #109 
- Resolves : #120 
---

## 🎸 기타 사항 or 추가 코멘트
- 저번에도 이런 실수가 있었는데,, 앞으로 머지 전에 테스트 코드를 무조건 돌려봐야겠습니다ㅜㅜ