### PR TITLE
Fix: (#127) 중복된 닉네임일 때 에러 처리가 아닌 DTO에 중복 결과를 반환한다

### DIFF
--- a/src/main/java/spring/backend/member/application/ValidateNicknameService.java
+++ b/src/main/java/spring/backend/member/application/ValidateNicknameService.java
@@ -5,7 +5,6 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import spring.backend.member.domain.repository.MemberRepository;
 import spring.backend.member.domain.value.Role;
-import spring.backend.member.exception.MemberErrorCode;
 
 @Service
 @RequiredArgsConstructor
@@ -17,18 +16,19 @@ public class ValidateNicknameService {
     public boolean validateNickname(String nickname) {
         if (nickname == null || nickname.isBlank()) {
             log.error("[ValidateNicknameService] Nickname is empty");
-            throw MemberErrorCode.NOT_EXIST_NICKNAME.toException();
+            return false;
         }
         if (nickname.length() > 6) {
             log.error("[ValidateNicknameService] Nickname is smaller than 6 characters");
-            throw MemberErrorCode.INVALID_NICKNAME_LENGTH.toException();
+            return false;
         }
         if (!nickname.matches("^[a-zA-Z0-9가-힣]+$")) {
             log.error("[ValidateNicknameService] Nickname is invalid");
-            throw MemberErrorCode.INVALID_NICKNAME_FORMAT.toException();
+            return false;
         }
         if (memberRepository.existsByNicknameAndRole(nickname, Role.MEMBER)) {
-            throw MemberErrorCode.ALREADY_REGISTERED_NICKNAME.toException();
+            log.error("[ValidateNicknameService] Nickname is already in use");
+            return false;
         }
         return true;
     }

--- a/src/main/java/spring/backend/member/presentation/swagger/ValidateNicknameSwagger.java
+++ b/src/main/java/spring/backend/member/presentation/swagger/ValidateNicknameSwagger.java
@@ -14,7 +14,7 @@ public interface ValidateNicknameSwagger {
 
     @Operation(
             summary = "닉네임 중복 검증 API",
-            description = "닉네임이 조건에 충족하지 않거나 중복일 경우, 에러를 발생합니다.",
+            description = "닉네임이 조건에 충족하지 않거나 중복일 경우 false를 반환합니다.",
             operationId = "/v1/members/check-nickname"
     )
     @ApiErrorCode({GlobalErrorCode.class, MemberErrorCode.class})


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- AS-IS : 중복된 닉네임일 경우, 에러 반환
- TO-BE : 중복된 닉네임일 경우, 응답으로 false 반환 (중복 아니면 true)

#### 중복일 경우
<img width="731" alt="스크린샷 2024-11-23 오후 3 34 02" src="https://github.com/user-attachments/assets/dfd8b058-4b2d-4eac-8443-8a56671a2e29">

#### 중복 아닐 경우
<img width="518" alt="스크린샷 2024-11-23 오후 3 34 10" src="https://github.com/user-attachments/assets/c0093c4f-d8ef-4acd-ba47-33231caa1c89">

---

## ✏️ 관련 이슈
- Fixes : #44 
- Resolves : #127 

---

## 🎸 기타 사항 or 추가 코멘트

