### PR TITLE
Fix: (#129) 중복 닉네임 검증에서 반환 값이 변경되면서 테스트 코드를 수정한다

### DIFF
--- a/src/test/java/spring/backend/member/application/ValidateNicknameServiceTest.java
+++ b/src/test/java/spring/backend/member/application/ValidateNicknameServiceTest.java
@@ -6,13 +6,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import spring.backend.core.exception.DomainException;
 import spring.backend.member.domain.repository.MemberRepository;
 import spring.backend.member.domain.value.Role;
-import spring.backend.member.exception.MemberErrorCode;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -35,11 +32,8 @@ class ValidateNicknameServiceTest {
         // Given
         String nickname = " ";
 
-        // When
-        DomainException blankException = assertThrows(DomainException.class, () -> validateNicknameService.validateNickname(nickname));
-
-        // Then
-        assertEquals(MemberErrorCode.NOT_EXIST_NICKNAME.name(), blankException.getCode());
+        // When & Then
+        assertFalse(validateNicknameService.validateNickname(nickname));
     }
 
     @Test
@@ -48,11 +42,8 @@ class ValidateNicknameServiceTest {
         // Given
         String nickname = "1234567";
 
-        // When
-        DomainException longLengthException = assertThrows(DomainException.class, () -> validateNicknameService.validateNickname(nickname));
-
-        // Then
-        assertEquals(MemberErrorCode.INVALID_NICKNAME_LENGTH.name(), longLengthException.getCode());
+        // When & Then
+        assertFalse(validateNicknameService.validateNickname(nickname));
     }
 
     @Test
@@ -61,11 +52,8 @@ class ValidateNicknameServiceTest {
         // Given
         String nickname = "조각ㅈㄱ";
 
-        // When
-        DomainException formatException = assertThrows(DomainException.class, () -> validateNicknameService.validateNickname(nickname));
-
-        // Then
-        assertEquals(MemberErrorCode.INVALID_NICKNAME_FORMAT.name(), formatException.getCode());
+        // When & Then
+        assertFalse(validateNicknameService.validateNickname(nickname));
     }
 
     @Test
@@ -75,11 +63,8 @@ class ValidateNicknameServiceTest {
         String nickname = "등록된이름";
         when(memberRepository.existsByNicknameAndRole(nickname, Role.MEMBER)).thenReturn(true);
 
-        // When
-        DomainException alreadyRegisteredException = assertThrows(DomainException.class, () -> validateNicknameService.validateNickname(nickname));
-
-        // Then
-        assertEquals(MemberErrorCode.ALREADY_REGISTERED_NICKNAME.name(), alreadyRegisteredException.getCode());
+        // When & Then
+        assertFalse(validateNicknameService.validateNickname(nickname));
 
         // Mock 객체 정상 동작 확인
         verify(memberRepository).existsByNicknameAndRole(nickname, Role.MEMBER);


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 중복 닉네임 검증 반환 시 에러가 아닌 boolean이 반환되는데 테스트 코드를 고치지 못한 이슈 대응 작업입니다.
<img width="542" alt="스크린샷 2024-11-23 오후 3 46 00" src="https://github.com/user-attachments/assets/30ac956c-6509-440c-86a5-38f5e13c64dd">


---

## ✏️ 관련 이슈
- Fixes : #127 
- Resolves : #129 

---

## 🎸 기타 사항 or 추가 코멘트
아.. 어제 이제 수정하고 테스트 코드 돌리고 머지하겠다고 반성했는데... 다음부터 수정 작업 시 무조건 테스트코드 돌리겠습니다ㅜㅜ