### PR TITLE
Feat: (#124) 마이페이지 이메일 알림을 설정할 수 있다

### DIFF
--- a/src/main/java/spring/backend/member/domain/entity/Member.java
+++ b/src/main/java/spring/backend/member/domain/entity/Member.java
@@ -31,6 +31,9 @@ public class Member {
 
     private String profileImage;
 
+    @Builder.Default
+    private boolean emailNotification = true;
+
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
@@ -47,6 +50,7 @@ public class Member {
                 .birthYear(memberJpaEntity.getBirthYear())
                 .gender(memberJpaEntity.getGender())
                 .profileImage(memberJpaEntity.getProfileImage())
+                .emailNotification(memberJpaEntity.isEmailNotification())
                 .createdAt(memberJpaEntity.getCreatedAt())
                 .updatedAt(memberJpaEntity.getUpdatedAt())
                 .deleted(memberJpaEntity.getDeleted())
@@ -70,6 +74,15 @@ public class Member {
         this.birthYear = birthYear;
         this.gender = gender;
         this.profileImage = profileImage;
+    }
+
+    public void changeEmailNotification(boolean isEmailNotification) {
+        if (this.emailNotification == isEmailNotification) {
+            throw isEmailNotification
+                    ? MemberErrorCode.ALREADY_ENABLE_EMAIL_NOTIFICATION.toException()
+                    : MemberErrorCode.ALREADY_DISABLE_EMAIL_NOTIFICATION.toException();
+        }
+        this.emailNotification = isEmailNotification;
     }
 
     public static Member createGuestMember(Provider provider, String email, String nickname) {

--- a/src/main/java/spring/backend/member/domain/service/ChangeEmailNotificationService.java
+++ b/src/main/java/spring/backend/member/domain/service/ChangeEmailNotificationService.java
@@ -1,0 +1,21 @@
+package spring.backend.member.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.repository.MemberRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChangeEmailNotificationService {
+
+    private final MemberRepository memberRepository;
+
+    public void changeEmailNotification(Member member) {
+        boolean isEmailNotificationEnabled = member.isEmailNotification();
+        member.changeEmailNotification(!isEmailNotificationEnabled);
+        memberRepository.save(member);
+    }
+}

--- a/src/main/java/spring/backend/member/exception/MemberErrorCode.java
+++ b/src/main/java/spring/backend/member/exception/MemberErrorCode.java
@@ -19,7 +19,9 @@ public enum MemberErrorCode implements BaseErrorCode<DomainException> {
     INVALID_NICKNAME_LENGTH(HttpStatus.BAD_REQUEST, "닉네임은 1자에서 6자 사이여야 합니다."),
     INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "닉네임은 한글, 영문, 숫자 조합이어야 합니다."),
     ALREADY_REGISTERED_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임이 이미 사용 중입니다."),
-    NOT_AUTHORIZED_MEMBER(HttpStatus.FORBIDDEN, "회원가입을 완료한 사용자가 아닙니다.");
+    NOT_AUTHORIZED_MEMBER(HttpStatus.FORBIDDEN, "회원가입을 완료한 사용자가 아닙니다."),
+    ALREADY_ENABLE_EMAIL_NOTIFICATION(HttpStatus.BAD_REQUEST, "이메일 알림이 이미 활성화되어 있습니다."),
+    ALREADY_DISABLE_EMAIL_NOTIFICATION(HttpStatus.BAD_REQUEST, "이메일 알림이 이미 비활성화되어 있습니다.");
 
     private final HttpStatus httpStatus;
 

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/entity/MemberJpaEntity.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/entity/MemberJpaEntity.java
@@ -40,6 +40,8 @@ public class MemberJpaEntity extends BaseEntity {
 
     private String profileImage;
 
+    private boolean emailNotification;
+
     public static MemberJpaEntity toJpaEntity(Member member) {
         return MemberJpaEntity.builder()
                 .id(member.getId())
@@ -50,6 +52,7 @@ public class MemberJpaEntity extends BaseEntity {
                 .birthYear(member.getBirthYear())
                 .gender(member.getGender())
                 .profileImage(member.getProfileImage())
+                .emailNotification(member.isEmailNotification())
                 .createdAt(member.getCreatedAt())
                 .updatedAt(member.getUpdatedAt())
                 .deleted(Optional.ofNullable(member.getDeleted()).orElse(false))

--- a/src/main/java/spring/backend/member/presentation/ChangeEmailNotificationController.java
+++ b/src/main/java/spring/backend/member/presentation/ChangeEmailNotificationController.java
@@ -8,10 +8,11 @@ import spring.backend.core.configuration.argumentresolver.AuthorizedMember;
 import spring.backend.core.configuration.interceptor.Authorization;
 import spring.backend.member.domain.entity.Member;
 import spring.backend.member.domain.service.ChangeEmailNotificationService;
+import spring.backend.member.presentation.swagger.ChangeEmailNotificationSwagger;
 
 @RestController
 @RequiredArgsConstructor
-public class ChangeEmailNotificationController {
+public class ChangeEmailNotificationController implements ChangeEmailNotificationSwagger {
 
     private final ChangeEmailNotificationService changeEmailNotificationService;
 

--- a/src/main/java/spring/backend/member/presentation/ChangeEmailNotificationController.java
+++ b/src/main/java/spring/backend/member/presentation/ChangeEmailNotificationController.java
@@ -1,0 +1,24 @@
+package spring.backend.member.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RestController;
+import spring.backend.core.configuration.argumentresolver.AuthorizedMember;
+import spring.backend.core.configuration.interceptor.Authorization;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.service.ChangeEmailNotificationService;
+
+@RestController
+@RequiredArgsConstructor
+public class ChangeEmailNotificationController {
+
+    private final ChangeEmailNotificationService changeEmailNotificationService;
+
+    @Authorization
+    @PatchMapping("/v1/members/email-notification")
+    public ResponseEntity<Void> changeEmailNotification(@AuthorizedMember Member member) {
+        changeEmailNotificationService.changeEmailNotification(member);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/spring/backend/member/presentation/swagger/ChangeEmailNotificationSwagger.java
+++ b/src/main/java/spring/backend/member/presentation/swagger/ChangeEmailNotificationSwagger.java
@@ -1,0 +1,22 @@
+package spring.backend.member.presentation.swagger;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import spring.backend.core.configuration.swagger.ApiErrorCode;
+import spring.backend.core.exception.error.GlobalErrorCode;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.exception.MemberErrorCode;
+
+@Tag(name = "Member", description = "멤버")
+public interface ChangeEmailNotificationSwagger {
+
+    @Operation(
+            summary = "이메일 알림 설정 API",
+            description = "사용자의 이메일 알림 설정을 변경합니다. \n\n 기본적으로 이메일 알림은 활성화되어 있으며, 요청을 통해 활성화 또는 비활성화할 수 있습니다.",
+            operationId = "/v1/members/email-notification"
+    )
+    @ApiErrorCode({GlobalErrorCode.class, MemberErrorCode.class})
+    ResponseEntity<Void> changeEmailNotification(@Parameter(hidden = true) Member member);
+}

--- a/src/test/java/spring/backend/member/domain/entity/MemberTest.java
+++ b/src/test/java/spring/backend/member/domain/entity/MemberTest.java
@@ -1,0 +1,38 @@
+package spring.backend.member.domain.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import spring.backend.core.exception.DomainException;
+import spring.backend.member.exception.MemberErrorCode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MemberTest {
+
+    @DisplayName("이메일 알림이 이미 활성화된 상태에서 다시 활성화하려고 하면 예외가 발생한다.")
+    @Test
+    void changeEmailNotification_throwsException_whenAlreadyEnabled() {
+        // Given
+        Member member = Member.builder()
+                .emailNotification(true)
+                .build();
+
+        // Then
+        DomainException ex = assertThrows(DomainException.class, () -> member.changeEmailNotification(true));
+        assertEquals(MemberErrorCode.ALREADY_ENABLE_EMAIL_NOTIFICATION.getMessage(), ex.getMessage());
+    }
+
+    @DisplayName("이메일 알림이 이미 비활성화된 상태에서 다시 비활성화하려고 하면 예외가 발생한다.")
+    @Test
+    void changeEmailNotification_throwsException_whenAlreadyDisabled() {
+        // Given
+        Member member = Member.builder()
+                .emailNotification(false)
+                .build();
+
+        // Then
+        DomainException ex = assertThrows(DomainException.class, () -> member.changeEmailNotification(false));
+        assertEquals(MemberErrorCode.ALREADY_DISABLE_EMAIL_NOTIFICATION.getMessage(), ex.getMessage());
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 마이페이지 이메일 알림 설정 API를 구현합니다.
- 도메인 모델에 이메일 알림 여부 필드를 추가하였습니다. 이메일 알림 여부는 기본 값은 True입니다.

#### 성공 응답
<img width="694" alt="스크린샷 2024-11-23 오후 8 56 09" src="https://github.com/user-attachments/assets/6fc9c5ec-e757-4501-9ccd-adadd2c70759">


---

## ✏️ 관련 이슈
- Resolves : #124 

---

## 🎸 기타 사항 or 추가 코멘트