### PR TITLE
Feat: (#135) 로그인, 온보딩 응답에 사용자 정보를 추가한다

### DIFF
--- a/src/main/java/spring/backend/auth/application/HandleOAuthLoginService.java
+++ b/src/main/java/spring/backend/auth/application/HandleOAuthLoginService.java
@@ -53,7 +53,6 @@ public class HandleOAuthLoginService {
                 .build();
 
         Member member = createMemberWithOAuthService.createMemberWithOAuth(createMemberWithOAuthRequest);
-
-        return new LoginResponse(jwtService.provideAccessToken(member), refreshTokenService.saveRefreshToken(member), member.getRole());
+        return LoginResponse.of(jwtService.provideAccessToken(member), refreshTokenService.saveRefreshToken(member), member.getRole(), member.getCreatedAt());
     }
 }

--- a/src/main/java/spring/backend/auth/application/OnboardingSignUpService.java
+++ b/src/main/java/spring/backend/auth/application/OnboardingSignUpService.java
@@ -5,6 +5,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import spring.backend.auth.dto.request.OnboardingSignUpRequest;
+import spring.backend.auth.dto.response.OnboardingSignUpResponse;
 import spring.backend.auth.exception.AuthenticationErrorCode;
 import spring.backend.member.domain.entity.Member;
 import spring.backend.member.domain.repository.MemberRepository;
@@ -21,12 +22,13 @@ public class OnboardingSignUpService {
 
     private final MemberRepository memberRepository;
 
-    public Member onboardingSignUp(Member member, OnboardingSignUpRequest request) {
+    public OnboardingSignUpResponse onboardingSignUp(Member member, OnboardingSignUpRequest request) {
         validateMember(member);
         validateRequest(request);
         validateBirthYear(request);
         member.convertGuestToMember(request.nickname(), request.birthYear(), request.gender(), request.profileImage());
-        return memberRepository.save(member);
+        memberRepository.save(member);
+        return OnboardingSignUpResponse.of(member.getEmail(), member.getNickname(), member.getBirthYear(), member.getGender(), member.getProfileImage(), member.getCreatedAt());
     }
 
     private void validateMember(Member member) {

--- a/src/main/java/spring/backend/auth/dto/response/LoginResponse.java
+++ b/src/main/java/spring/backend/auth/dto/response/LoginResponse.java
@@ -1,6 +1,25 @@
 package spring.backend.auth.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import spring.backend.member.domain.value.Role;
 
-public record LoginResponse(String accessToken, String refreshToken, Role role) {
+import java.time.LocalDateTime;
+
+public record LoginResponse(
+
+        @Schema(description = "액세스 토큰")
+        String accessToken,
+
+        @Schema(description = "리프레시 토큰")
+        String refreshToken,
+
+        @Schema(description = "사용자 유형(MEMBER, GUEST)", example = "MEMBER")
+        Role role,
+
+        @Schema(description = "사용자 가입 날짜", example = "2024-11-14T06:10:55.091954")
+        LocalDateTime registrationDate
+) {
+    public static LoginResponse of(String accessToken, String refreshToken, Role role, LocalDateTime registrationDate) {
+        return new LoginResponse(accessToken, refreshToken, role, registrationDate);
+    }
 }

--- a/src/main/java/spring/backend/auth/dto/response/OnboardingSignUpResponse.java
+++ b/src/main/java/spring/backend/auth/dto/response/OnboardingSignUpResponse.java
@@ -1,0 +1,31 @@
+package spring.backend.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import spring.backend.member.domain.value.Gender;
+
+import java.time.LocalDateTime;
+
+public record OnboardingSignUpResponse(
+
+        @Schema(description = "사용자 이메일", example = "example@example.com")
+        String email,
+
+        @Schema(description = "사용자 닉네임", example = "john_doe")
+        String nickname,
+
+        @Schema(description = "사용자 출생 연도", example = "1990")
+        int birthYear,
+
+        @Schema(description = "사용자 성별 (MALE, FEMALE, NONE)", example = "MALE")
+        Gender gender,
+
+        @Schema(description = "사용자 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String profileImage,
+
+        @Schema(description = "사용자 가입 날짜", example = "2024-11-14T06:10:55.091954")
+        LocalDateTime registrationDate
+){
+    public static OnboardingSignUpResponse of(String email, String nickname, int birthYear, Gender gender, String profileImage, LocalDateTime registrationDate) {
+        return new OnboardingSignUpResponse(email, nickname, birthYear, gender, profileImage, registrationDate);
+    }
+}

--- a/src/main/java/spring/backend/auth/presentation/OnboardingSignUpController.java
+++ b/src/main/java/spring/backend/auth/presentation/OnboardingSignUpController.java
@@ -8,13 +8,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import spring.backend.auth.application.OnboardingSignUpService;
 import spring.backend.auth.dto.request.OnboardingSignUpRequest;
+import spring.backend.auth.dto.response.OnboardingSignUpResponse;
 import spring.backend.auth.presentation.swagger.OnboardingSignUpSwagger;
 import spring.backend.core.configuration.argumentresolver.LoginMember;
 import spring.backend.core.configuration.interceptor.Authorization;
 import spring.backend.core.presentation.RestResponse;
 import spring.backend.member.domain.entity.Member;
-
-import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,8 +23,8 @@ public class OnboardingSignUpController implements OnboardingSignUpSwagger {
 
     @Authorization
     @PostMapping("/v1/members/onboard")
-    public ResponseEntity<RestResponse<UUID>> onboardingSignUp(@LoginMember Member member, @Valid @RequestBody OnboardingSignUpRequest request) {
-        Member updatedMember = onboardingSignUpService.onboardingSignUp(member, request);
-        return ResponseEntity.ok(new RestResponse<>(updatedMember.getId()));
+    public ResponseEntity<RestResponse<OnboardingSignUpResponse>> onboardingSignUp(@LoginMember Member member, @Valid @RequestBody OnboardingSignUpRequest request) {
+        OnboardingSignUpResponse onboardingSignUpResponse = onboardingSignUpService.onboardingSignUp(member, request);
+        return ResponseEntity.ok(new RestResponse<>(onboardingSignUpResponse));
     }
 }

--- a/src/main/java/spring/backend/auth/presentation/swagger/OnboardingSignUpSwagger.java
+++ b/src/main/java/spring/backend/auth/presentation/swagger/OnboardingSignUpSwagger.java
@@ -5,14 +5,13 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import spring.backend.auth.dto.request.OnboardingSignUpRequest;
+import spring.backend.auth.dto.response.OnboardingSignUpResponse;
 import spring.backend.auth.exception.AuthenticationErrorCode;
 import spring.backend.core.configuration.swagger.ApiErrorCode;
 import spring.backend.core.exception.error.GlobalErrorCode;
 import spring.backend.core.presentation.RestResponse;
 import spring.backend.member.domain.entity.Member;
 import spring.backend.member.exception.MemberErrorCode;
-
-import java.util.UUID;
 
 @Tag(name = "Auth", description = "인증/인가")
 public interface OnboardingSignUpSwagger {
@@ -23,5 +22,5 @@ public interface OnboardingSignUpSwagger {
             operationId = "/v1/members/onboard"
     )
     @ApiErrorCode({GlobalErrorCode.class, AuthenticationErrorCode.class, MemberErrorCode.class})
-    ResponseEntity<RestResponse<UUID>> onboardingSignUp(@Parameter(hidden = true) Member member, OnboardingSignUpRequest request);
+    ResponseEntity<RestResponse<OnboardingSignUpResponse>> onboardingSignUp(@Parameter(hidden = true) Member member, OnboardingSignUpRequest request);
 }

--- a/src/test/java/spring/backend/auth/application/OnboardingSignUpServiceTest.java
+++ b/src/test/java/spring/backend/auth/application/OnboardingSignUpServiceTest.java
@@ -7,6 +7,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import spring.backend.auth.dto.request.OnboardingSignUpRequest;
+import spring.backend.auth.dto.response.OnboardingSignUpResponse;
 import spring.backend.auth.exception.AuthenticationErrorCode;
 import spring.backend.core.exception.DomainException;
 import spring.backend.member.domain.entity.Member;
@@ -76,10 +77,11 @@ class OnboardingSignUpServiceTest {
         when(memberRepository.save(any(Member.class))).thenReturn(member);
 
         // When
-        Member result = onboardingSignUpService.onboardingSignUp(member, request);
+        OnboardingSignUpResponse onboardingSignUpResponse = onboardingSignUpService.onboardingSignUp(member, request);
 
         // Then
-        assertNotNull(result);
+        assertNotNull(onboardingSignUpResponse);
+
         verify(member).convertGuestToMember("조각조각", 2001, Gender.MALE, "http://test.jpg");
         verify(memberRepository).save(member);
     }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 로그인, 온보딩 작업에서 사용자 정보와 가입 날짜를 반환합니다.
- 로그인 : 가입날짜 (registrationDate)
- 온보딩 : UserInfo(+ 가입날짜)

<img width="424" alt="스크린샷 2024-11-24 오전 4 56 20" src="https://github.com/user-attachments/assets/b277a873-2bc7-4528-aa4f-570bdf38d57a">
<img width="483" alt="스크린샷 2024-11-24 오전 5 05 34" src="https://github.com/user-attachments/assets/336a70be-9fc2-4f13-a64e-87c6381fcb30">


---

## ✏️ 관련 이슈
- Resolves : #135 

---

## 🎸 기타 사항 or 추가 코멘트