### PR TITLE
Fix: (#139) 배포 서버 JVM의 타임존을 Asia/Seoul으로 변경한다

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     container_name: cnergy-backend-blue
     env_file:
       - .env
+    environment:
+      TZ: Asia/Seoul
     ports:
       - '8080:8080'
     depends_on:
@@ -16,6 +18,8 @@ services:
     container_name: cnergy-backend-green
     env_file:
       - .env
+    environment:
+      TZ: Asia/Seoul
     ports:
       - '8081:8080'
     depends_on:


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 현재 배포 서버와 RDS의 타임존은 Asia/Seoul로 설정되어있으나, 도커 컨테이너는 UTC로 되어있어 JVM 역시 컨테이너의 시간을 사용하고 있어 서울 시간과 맞지 않는 이슈 대응 작업입니다.
- 도커 컨테이너의 Timezone을 Asia/Seoul로 설정하였습니다.

#### docker container 시간 확인
![스크린샷 2024-11-25 오후 7 04 13](https://github.com/user-attachments/assets/00118430-f0c2-4f14-a0e3-9fcb7cd84c76)

#### id 8번 -> Seoul 시간에 저장 확인
![스크린샷 2024-11-25 오후 7 15 54](https://github.com/user-attachments/assets/49ff80a0-44fc-41fe-a77e-ee16503000c6)

---

## ✏️ 관련 이슈
- Resolves : #139 

---

## 🎸 기타 사항 or 추가 코멘트