### PR TITLE
Fix: (#138) Keyword 밸류 타입 POJO화 및 @Embeddable로 인프라 레이어에 추가한다

### DIFF
--- a/src/main/java/spring/backend/activity/domain/value/Keyword.java
+++ b/src/main/java/spring/backend/activity/domain/value/Keyword.java
@@ -1,25 +1,22 @@
 package spring.backend.activity.domain.value;
 
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-@Embeddable
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class Keyword {
 
-    @Enumerated(EnumType.STRING)
-    private Category category;
+    private final Category category;
 
-    private String image;
+    private final String image;
 
     @Getter
     @RequiredArgsConstructor

--- a/src/main/java/spring/backend/activity/dto/response/HomeActivityInfoResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/HomeActivityInfoResponse.java
@@ -1,7 +1,7 @@
 package spring.backend.activity.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import spring.backend.activity.domain.value.Keyword;
+import spring.backend.activity.infrastructure.persistence.jpa.value.KeywordJpaValue;
 
 public record HomeActivityInfoResponse(
 
@@ -9,7 +9,7 @@ public record HomeActivityInfoResponse(
         Long id,
 
         @Schema(description = "활동 키워드", example = "{\"category\": \"SELF_DEVELOPMENT\", \"image\": \"https://example.com/image.jpg\"}")
-        Keyword keyword,
+        KeywordJpaValue keyword,
 
         @Schema(description = "활동 제목", example = "마음의 편안을 가져다주는 명상음악 20분 듣기")
         String title,

--- a/src/main/java/spring/backend/activity/dto/response/MonthlyActivityCountByKeywordResponse.java
+++ b/src/main/java/spring/backend/activity/dto/response/MonthlyActivityCountByKeywordResponse.java
@@ -1,11 +1,11 @@
 package spring.backend.activity.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import spring.backend.activity.domain.value.Keyword;
+import spring.backend.activity.infrastructure.persistence.jpa.value.KeywordJpaValue;
 
 public record MonthlyActivityCountByKeywordResponse(
         @Schema(description = "활동의 Keyword" , example = "{\"category\": \"SELF_DEVELOPMENT\", \"image\": \"https://example.com/image.jpg\"}")
-        Keyword keyword,
+        KeywordJpaValue keyword,
 
         @Schema(description = "Keyword별 활동 횟수" , example = "2")
         long activityCount

--- a/src/main/java/spring/backend/activity/infrastructure/mapper/ActivityMapper.java
+++ b/src/main/java/spring/backend/activity/infrastructure/mapper/ActivityMapper.java
@@ -2,7 +2,9 @@ package spring.backend.activity.infrastructure.mapper;
 
 import org.springframework.stereotype.Component;
 import spring.backend.activity.domain.entity.Activity;
+import spring.backend.activity.domain.value.Keyword;
 import spring.backend.activity.infrastructure.persistence.jpa.entity.ActivityJpaEntity;
+import spring.backend.activity.infrastructure.persistence.jpa.value.KeywordJpaValue;
 
 import java.util.Optional;
 
@@ -16,7 +18,7 @@ public class ActivityMapper {
                 .quickStartId(activity.getQuickStartId())
                 .spareTime(activity.getSpareTime())
                 .type(activity.getType())
-                .keyword(activity.getKeyword())
+                .keyword(toDomainValue(activity.getKeyword()))
                 .title(activity.getTitle())
                 .content(activity.getContent())
                 .location(activity.getLocation())
@@ -36,7 +38,7 @@ public class ActivityMapper {
                 .quickStartId(activity.getQuickStartId())
                 .spareTime(activity.getSpareTime())
                 .type(activity.getType())
-                .keyword(activity.getKeyword())
+                .keyword(toJpaValue(activity.getKeyword()))
                 .title(activity.getTitle())
                 .content(activity.getContent())
                 .location(activity.getLocation())
@@ -47,5 +49,13 @@ public class ActivityMapper {
                 .updatedAt(activity.getUpdatedAt())
                 .deleted(Optional.ofNullable(activity.getDeleted()).orElse(false))
                 .build();
+    }
+
+    private Keyword toDomainValue(KeywordJpaValue keywordJpaValue) {
+        return Keyword.create(keywordJpaValue.getCategory(), keywordJpaValue.getImage());
+    }
+
+    private KeywordJpaValue toJpaValue(Keyword keyword) {
+        return KeywordJpaValue.create(keyword.getCategory(), keyword.getImage());
     }
 }

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/entity/ActivityJpaEntity.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/entity/ActivityJpaEntity.java
@@ -5,7 +5,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import spring.backend.activity.domain.value.Keyword;
+import spring.backend.activity.infrastructure.persistence.jpa.value.KeywordJpaValue;
 import spring.backend.activity.domain.value.Type;
 import spring.backend.activity.exception.ActivityErrorCode;
 import spring.backend.core.infrastructure.jpa.shared.BaseLongIdEntity;
@@ -30,7 +30,7 @@ public class ActivityJpaEntity extends BaseLongIdEntity {
     private Type type;
 
     @Embedded
-    private Keyword keyword;
+    private KeywordJpaValue keyword;
 
     private String title;
 

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/value/KeywordJpaValue.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/value/KeywordJpaValue.java
@@ -1,0 +1,24 @@
+package spring.backend.activity.infrastructure.persistence.jpa.value;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.*;
+import spring.backend.activity.domain.value.Keyword.Category;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class KeywordJpaValue {
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+
+    private String image;
+
+    public static KeywordJpaValue create(Category category, String image) {
+        return new KeywordJpaValue(category, image);
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
[개발 피드백](https://github.com/KUSITMS-30th-TEAM-C/backend/pull/76#discussion_r1831021713)
```
클린아키텍처를 사용한것은 아닌가요?
domain layer가 POJO로 되어있고 의존성도 application -> domain <- infra 로 가고있는거 같아서 
클린아키텍처 + DDD라고 생각했는데 여기 jakarta쪽 어노테이션이 있군요
```

- 기존 도메인 모델과 JPA 엔티티를 분리한 것처럼, Keyword 밸류 타입도 POJO(Domain) 객체와 JPA(Infra) 객체로 변경하는 작업입니다.
- DB 저장 및 모든 스웨거 API 동작 확인했습니다!
---

## ✏️ 관련 이슈
- Fixes : #55 
- Resolves : #138 

---

## 🎸 기타 사항 or 추가 코멘트