### PR TITLE
Fix: (#146) 로그인 시 온보딩을 진행하지 않은 사용자의 닉네임은 null로 반환한다

### DIFF
--- a/src/main/java/spring/backend/auth/application/HandleOAuthLoginService.java
+++ b/src/main/java/spring/backend/auth/application/HandleOAuthLoginService.java
@@ -49,7 +49,6 @@ public class HandleOAuthLoginService {
         CreateMemberWithOAuthRequest createMemberWithOAuthRequest = CreateMemberWithOAuthRequest.builder()
                 .provider(provider)
                 .email(oAuthResourceResponse.getEmail())
-                .nickname(oAuthResourceResponse.getName())
                 .build();
 
         Member member = createMemberWithOAuthService.createMemberWithOAuth(createMemberWithOAuthRequest);

--- a/src/main/java/spring/backend/member/application/CreateMemberWithOAuthService.java
+++ b/src/main/java/spring/backend/member/application/CreateMemberWithOAuthService.java
@@ -24,7 +24,7 @@ public class CreateMemberWithOAuthService {
         }
         List<Member> members = memberRepository.findAllByEmail(request.getEmail());
         if (members == null || members.isEmpty()) {
-            Member newMember = Member.createGuestMember(request.getProvider(), request.getEmail(), request.getNickname());
+            Member newMember = Member.createGuestMember(request.getProvider(), request.getEmail());
             Member savedMember = memberRepository.save(newMember);
 
             if (savedMember == null) {
@@ -49,7 +49,7 @@ public class CreateMemberWithOAuthService {
                 .filter(m -> m.isSameProvider(request.getProvider()))
                 .findFirst()
                 .orElseGet(() -> {
-                    Member newMember = Member.createGuestMember(request.getProvider(), request.getEmail(), request.getNickname());
+                    Member newMember = Member.createGuestMember(request.getProvider(), request.getEmail());
                     Member savedMember = memberRepository.save(newMember);
 
                     if (savedMember == null) {

--- a/src/main/java/spring/backend/member/domain/entity/Member.java
+++ b/src/main/java/spring/backend/member/domain/entity/Member.java
@@ -85,12 +85,11 @@ public class Member {
         this.emailNotification = isEmailNotification;
     }
 
-    public static Member createGuestMember(Provider provider, String email, String nickname) {
+    public static Member createGuestMember(Provider provider, String email) {
         return Member.builder()
                 .provider(provider)
                 .role(Role.GUEST)
                 .email(email)
-                .nickname(nickname)
                 .build();
     }
 

--- a/src/test/java/spring/backend/member/application/CreateMemberWithOAuthServiceTest.java
+++ b/src/test/java/spring/backend/member/application/CreateMemberWithOAuthServiceTest.java
@@ -1,0 +1,50 @@
+package spring.backend.member.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.repository.MemberRepository;
+import spring.backend.member.domain.value.Provider;
+import spring.backend.member.domain.value.Role;
+import spring.backend.member.dto.request.CreateMemberWithOAuthRequest;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CreateMemberWithOAuthServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private CreateMemberWithOAuthService createMemberWithOAuthService;
+
+    @DisplayName("Role이 GUEST인 경우 닉네임은 null이어야 한다")
+    @Test
+    void createGuestMember_returnsGuestMemberWithoutNickname() {
+        // given
+        CreateMemberWithOAuthRequest request = CreateMemberWithOAuthRequest.builder()
+                .provider(Provider.GOOGLE)
+                .email("jogakjogak@gmail.com")
+                .build();
+
+        // when
+        Member newMember = Member.createGuestMember(request.getProvider(), request.getEmail());
+        when(memberRepository.save(any(Member.class))).thenReturn(newMember);
+        Member result = createMemberWithOAuthService.createMemberWithOAuth(request);
+
+        // then
+        assertNotNull(result);
+        assertEquals(Provider.GOOGLE, result.getProvider());
+        assertEquals("jogakjogak@gmail.com", result.getEmail());
+        assertEquals(Role.GUEST, result.getRole());
+        assertNull(result.getNickname());
+        verify(memberRepository, times(1)).save(any(Member.class));
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- QA 이슈 대응 작업으로, 온보딩 가입 시작 시 기존 OAuth 써드파티 제공자에서 가져오는 이름을 nickname으로 저장했지만, 사용자에게 빈값으로 노출시켜야해서 변경하였습니다.

#### [로그인] GUEST일 때 응답
![스크린샷 2024-11-26 오전 5 06 58](https://github.com/user-attachments/assets/cb3196e1-5091-499c-bdd3-b0acf500728f)

#### [로그인] MEMBER일 때 응답
![스크린샷 2024-11-26 오전 5 09 09](https://github.com/user-attachments/assets/344d65c4-a934-4ba4-9b48-3e7e202297e5)

---

## ✏️ 관련 이슈
- Fixes : #15 
- Resolves : #146 

---

## 🎸 기타 사항 or 추가 코멘트