### PR TITLE
Refactor: (#148) 멤버 생성 서비스에서 함수를 분리하고 @Transactional를 붙여 가독성과 안정성을 높일 수 있다

### DIFF
--- a/src/main/java/spring/backend/member/application/CreateMemberWithOAuthService.java
+++ b/src/main/java/spring/backend/member/application/CreateMemberWithOAuthService.java
@@ -3,6 +3,7 @@ package spring.backend.member.application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import spring.backend.member.domain.entity.Member;
 import spring.backend.member.domain.repository.MemberRepository;
 import spring.backend.member.dto.request.CreateMemberWithOAuthRequest;
@@ -13,6 +14,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Log4j2
+@Transactional
 public class CreateMemberWithOAuthService {
 
     private final MemberRepository memberRepository;
@@ -22,22 +24,21 @@ public class CreateMemberWithOAuthService {
             log.error("[createMemberWithOAuth] request is null");
             throw MemberErrorCode.NOT_EXIST_CONDITION.toException();
         }
+
         List<Member> members = memberRepository.findAllByEmail(request.getEmail());
         if (members == null || members.isEmpty()) {
-            Member newMember = Member.createGuestMember(request.getProvider(), request.getEmail());
-            Member savedMember = memberRepository.save(newMember);
-
-            if (savedMember == null) {
-                log.error("[CreateMemberWithOAuthService] member could not be saved");
-                throw MemberErrorCode.MEMBER_SAVE_FAILED.toException();
-            }
-
-            return savedMember;
+            return createGuestMember(request);
         }
+
+        return handleExistingMember(members, request);
+    }
+
+    private Member handleExistingMember(List<Member> members, CreateMemberWithOAuthRequest request) {
         Member existingMember = members.stream()
                 .filter(Member::isMember)
                 .findFirst()
                 .orElse(null);
+
         if (existingMember != null) {
             if (!existingMember.isSameProvider(request.getProvider())) {
                 log.error("[CreateMemberWithOAuthService] member already exists with a different provider [{}]", existingMember.getProvider());
@@ -45,19 +46,24 @@ public class CreateMemberWithOAuthService {
             }
             return existingMember;
         }
+
         return members.stream()
                 .filter(m -> m.isSameProvider(request.getProvider()))
                 .findFirst()
-                .orElseGet(() -> {
-                    Member newMember = Member.createGuestMember(request.getProvider(), request.getEmail());
-                    Member savedMember = memberRepository.save(newMember);
+                .orElseGet(() -> createGuestMember(request));
+    }
 
-                    if (savedMember == null) {
-                        log.error("[CreateMemberWithOAuthService] member could not be saved");
-                        throw MemberErrorCode.MEMBER_SAVE_FAILED.toException();
-                    }
+    private Member createGuestMember(CreateMemberWithOAuthRequest request) {
+        Member newMember = Member.createGuestMember(request.getProvider(), request.getEmail());
+        return saveMember(newMember);
+    }
 
-                    return savedMember;
-                });
+    private Member saveMember(Member member) {
+        Member savedMember = memberRepository.save(member);
+        if (savedMember == null) {
+            log.error("[CreateMemberWithOAuthService] member could not be saved");
+            throw MemberErrorCode.MEMBER_SAVE_FAILED.toException();
+        }
+        return savedMember;
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
개발 피드백 [[함수 분리](https://github.com/KUSITMS-30th-TEAM-C/backend/pull/76#discussion_r1831100953), [@Transactional](https://github.com/KUSITMS-30th-TEAM-C/backend/pull/76#discussion_r1831102430)]

```
함수가 조금 긴것같은데, 적절히 분리해주셔도 가독성 향상에 좋을거 같습니다.
---
+Transactional을 붙여주는게 안정적이지 않을까요?
```

- 함수를 기능 단위로 분리하여 가독성을 높였습니다.
- 하나의 트랜잭션 단위로 묶어 처리하여 안정성을 높였습니다.

#### [로그인] GUEST일 때 응답
![스크린샷 2024-11-26 오전 6 12 38](https://github.com/user-attachments/assets/27138962-cfe5-4951-b9b2-e5de5a8a7978)

#### [로그인] MEMBER일 때 응답
![스크린샷 2024-11-26 오전 6 13 03](https://github.com/user-attachments/assets/c4ed3c24-5740-456a-944a-ab26f61e8b8c)



---

## ✏️ 관련 이슈
- Resolves : #148 

---

## 🎸 기타 사항 or 추가 코멘트