### PR TITLE
refactor: (#150) MemberID 생성시 Sequential UUID를 사용하도록 변경한다.

### DIFF
--- a/src/main/java/spring/backend/core/infrastructure/jpa/shared/BaseEntity.java
+++ b/src/main/java/spring/backend/core/infrastructure/jpa/shared/BaseEntity.java
@@ -3,9 +3,11 @@ package spring.backend.core.infrastructure.jpa.shared;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import spring.backend.core.infrastructure.persistence.interceptor.SequentialUUID;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -18,7 +20,7 @@ import java.util.UUID;
 public class BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
+    @SequentialUUID
     protected UUID id;
 
     @CreatedDate

--- a/src/main/java/spring/backend/core/infrastructure/jpa/shared/BaseEntity.java
+++ b/src/main/java/spring/backend/core/infrastructure/jpa/shared/BaseEntity.java
@@ -3,11 +3,10 @@ package spring.backend.core.infrastructure.jpa.shared;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import spring.backend.core.infrastructure.persistence.interceptor.SequentialUUID;
+import spring.backend.core.infrastructure.persistence.SequentialUUID;
 
 import java.time.LocalDateTime;
 import java.util.UUID;

--- a/src/main/java/spring/backend/core/infrastructure/persistence/SequentialUUID.java
+++ b/src/main/java/spring/backend/core/infrastructure/persistence/SequentialUUID.java
@@ -1,7 +1,6 @@
-package spring.backend.core.infrastructure.persistence.interceptor;
+package spring.backend.core.infrastructure.persistence;
 
 import org.hibernate.annotations.IdGeneratorType;
-import spring.backend.core.infrastructure.persistence.SequentialUUIDGenerator;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -9,7 +8,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @IdGeneratorType(SequentialUUIDGenerator.class)
-@Target({ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface SequentialUUID {
 }

--- a/src/main/java/spring/backend/core/infrastructure/persistence/SequentialUUIDGenerator.java
+++ b/src/main/java/spring/backend/core/infrastructure/persistence/SequentialUUIDGenerator.java
@@ -1,0 +1,19 @@
+package spring.backend.core.infrastructure.persistence;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.IdentifierGenerator;
+
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.UUID;
+
+public class SequentialUUIDGenerator implements IdentifierGenerator {
+
+    @Override
+    public Serializable generate(SharedSessionContractImplementor session, Object object) throws HibernateException {
+        long mostSignificantBits = Instant.now().toEpochMilli();
+        long leastSignificantBits = UUID.randomUUID().getLeastSignificantBits();
+        return new UUID(mostSignificantBits, leastSignificantBits);
+    }
+}

--- a/src/main/java/spring/backend/core/infrastructure/persistence/interceptor/SequentialUUID.java
+++ b/src/main/java/spring/backend/core/infrastructure/persistence/interceptor/SequentialUUID.java
@@ -1,0 +1,15 @@
+package spring.backend.core.infrastructure.persistence.interceptor;
+
+import org.hibernate.annotations.IdGeneratorType;
+import spring.backend.core.infrastructure.persistence.SequentialUUIDGenerator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@IdGeneratorType(SequentialUUIDGenerator.class)
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SequentialUUID {
+}

--- a/src/test/java/spring/backend/core/infrastructure/SequentialUUIDGeneratorTest.java
+++ b/src/test/java/spring/backend/core/infrastructure/SequentialUUIDGeneratorTest.java
@@ -1,0 +1,80 @@
+package spring.backend.core.infrastructure;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import spring.backend.member.domain.entity.Member;
+import spring.backend.member.domain.repository.MemberRepository;
+import spring.backend.member.domain.value.Provider;
+import spring.backend.member.domain.value.Role;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@SpringBootTest
+public class SequentialUUIDGeneratorTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("UUID가 순차적으로 생성되는지 확인한다.")
+    @Test
+    void testSequentialUUIDGenerator() {
+        // given
+        Member member1 = Member.builder()
+                .provider(Provider.GOOGLE)
+                .role(Role.GUEST)
+                .email("test1@test.com")
+                .build();
+
+        Member member2 = Member.builder()
+                .provider(Provider.GOOGLE)
+                .role(Role.GUEST)
+                .email("test2@test.com")
+                .build();
+
+        // when
+        Member saverMember1 = memberRepository.save(member1);
+        Member savedMember2 = memberRepository.save(member2);
+
+        // then
+        assertNotNull(saverMember1.getId());
+        assertNotNull(savedMember2.getId());
+
+        long timestamp1 = saverMember1.getId().getMostSignificantBits() >>> 16;
+        long timestamp2 = savedMember2.getId().getMostSignificantBits() >>> 16;
+        assertTrue(timestamp2 >= timestamp1);
+    }
+
+    @DisplayName("생성순서를 변경할 경우, UUID가 순차적으로 생성되는지 확인한다.")
+    @Test
+    void failedTestSequentialUUIDGenerator() {
+        // given
+        Member member1 = Member.builder()
+                .provider(Provider.GOOGLE)
+                .role(Role.GUEST)
+                .email("test1@test.com")
+                .build();
+
+        Member member2 = Member.builder()
+                .provider(Provider.GOOGLE)
+                .role(Role.GUEST)
+                .email("test2@test.com")
+                .build();
+
+        // when
+        Member savedMember2 = memberRepository.save(member2);
+        Member saverMember1 = memberRepository.save(member1);
+
+        // then
+        assertNotNull(saverMember1.getId());
+        assertNotNull(savedMember2.getId());
+
+        long timestamp1 = saverMember1.getId().getMostSignificantBits() >>> 16;
+        long timestamp2 = savedMember2.getId().getMostSignificantBits() >>> 16;
+
+        assertTrue(timestamp2 <= timestamp1);
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용

- MemberID 생성시 Sequential UUID를 사용하도록 변경한다.

![image](https://github.com/user-attachments/assets/3cf1d860-f11b-4d55-b846-3d173f1b35ea)


---

## ✏️ 관련 이슈

- Resolves : #150 


---

## 🎸 기타 사항 or 추가 코멘트
UUID 전략을 설정했을 때 아닐 때 테스트를 거쳤습니다.

참고
https://docs.jboss.org/hibernate/orm/6.6/userguide/html_single/Hibernate_User_Guide.html#identifiers-generators-IdGeneratorType