### PR TITLE
Fix: (#153) 메인 화면에서 현재 시간에 가장 가까운 빠른 시작을 가져오지 못하는 이슈 대응

### DIFF
--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/dao/QuickStartJpaDao.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/dao/QuickStartJpaDao.java
@@ -37,8 +37,10 @@ public interface QuickStartJpaDao extends JpaRepository<QuickStartJpaEntity, Lon
         )
         from QuickStartJpaEntity q
         where q.memberId = :memberId
-        and q.startTime > CURRENT_TIMESTAMP
-        order by q.startTime ASC
+        and (q.startTime > current_time or q.startTime <= current_time)
+        order by
+            case when q.startTime > current_time then 0 else 1 end,
+            q.startTime asc
     """)
     List<QuickStartResponse> findUpcomingQuickStarts(UUID memberId);
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- QA 진행 중 발생한 이슈입니다.
AS-IS
- 현재 API 조회 시점으로부터 가장 빠른 시작을 불러옴
- 문제 : 23시에 조회했을 때, 가장 빠른 시작이 오전 1시라면 불러오지 않는 문제 발생

TO-BE
- 빠른 시작이 있으면 가장 가까운 빠른 시작을 가져옵니다. (빠른 시작이 존재하면 무조건 반환)

#### 시간대를 설정해서 테스트할 수 없어 query를 통해 테스트 진행하였습니다. (23시 30분 기준)
![스크린샷 2024-11-27 오전 1 59 59](https://github.com/user-attachments/assets/cabbf8a1-b6af-433f-a4c3-060df2e4e3ab)
![스크린샷 2024-11-27 오전 2 00 04](https://github.com/user-attachments/assets/077827b4-8258-4f30-8ad5-4048cc28dbbd)



---

## ✏️ 관련 이슈
- Fixes : #70 
- Resolves : #153 

---

## 🎸 기타 사항 or 추가 코멘트