### PR TITLE
Feat: (#151) 빠른 시작 메일 전송 템플릿을 적용한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,9 @@ dependencies {
 	// Spring Batch
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	testImplementation 'org.springframework.batch:spring-batch-test'
+
+	// Thymeleaf
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/src/main/java/spring/backend/activity/application/SendQuickStartEmailsScheduler.java
+++ b/src/main/java/spring/backend/activity/application/SendQuickStartEmailsScheduler.java
@@ -6,6 +6,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
+import spring.backend.activity.domain.entity.QuickStart;
+import spring.backend.activity.domain.repository.QuickStartRepository;
 import spring.backend.core.util.email.EmailUtil;
 import spring.backend.core.util.email.dto.request.SendEmailRequest;
 import spring.backend.member.domain.entity.Member;
@@ -13,17 +15,23 @@ import spring.backend.member.domain.repository.MemberRepository;
 
 import java.time.LocalTime;
 import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Log4j2
 public class SendQuickStartEmailsScheduler {
 
+    private final QuickStartRepository quickStartRepository;
+
     private final MemberRepository memberRepository;
 
     private final EmailUtil emailUtil;
 
     private final TemplateEngine templateEngine;
+
+    private static final int TIME_INTERVAL_MINUTES = 15;
 
     @Scheduled(cron = "0 0/15 * * * ?")
     public void sendQuickStartEmails() {
@@ -36,35 +44,77 @@ public class SendQuickStartEmailsScheduler {
         }
     }
 
+    private void sendEmails(List<Member> receivers) {
+        List<UUID> receiverIds = receivers.stream()
+                .map(Member::getId)
+                .collect(Collectors.toList());
+
+        List<QuickStart> earliestQuickStartsForMembers = collectEarliestQuickStartsForMembers(receiverIds);
+
+        receivers.forEach(receiver -> {
+            QuickStart earliestQuickStart = findEarliestQuickStartForReceiver(receiver, earliestQuickStartsForMembers);
+            if (earliestQuickStart != null) {
+                sendEmail(receiver, earliestQuickStart);
+            } else {
+                log.warn("[SendQuickStartEmailsScheduler] No quick start found for receiver {}", receiver);
+            }
+        });
+    }
+
     private List<Member> collectEmailReceiversWithinTimeRange() {
-        final int TIME_INTERVAL_MINUTES = 15;
-        LocalTime now = LocalTime.now();
-        LocalTime lowerBound = now.plusMinutes(1).withSecond(0).withNano(0);
-        LocalTime upperBound = lowerBound.plusMinutes(TIME_INTERVAL_MINUTES - 1);
+        LocalTime lowerBound = getLowerBound();
+        LocalTime upperBound = getUpperBound(lowerBound);
 
         log.info("[SendQuickStartEmailsScheduler] Searching for receivers between {} and {}", lowerBound, upperBound);
 
         return memberRepository.findMembersForQuickStartsInTimeRange(lowerBound, upperBound);
     }
 
-    private void sendEmails(List<Member> receivers) {
-        for (Member receiver : receivers) {
-            SendEmailRequest request = SendEmailRequest.builder()
-                    .title("Test Title")
-                    .content(generateEmailContent())
-                    .receiver(receiver.getEmail())
-                    .build();
-            try {
-                emailUtil.send(request);
-                log.info("[SendQuickStartEmailsScheduler] Successfully sent email to {}", receiver);
-            } catch (Exception e) {
-                log.error("[SendQuickStartEmailsScheduler] Failed to send email to {}", receiver, e);
-            }
+    private List<QuickStart> collectEarliestQuickStartsForMembers(List<UUID> receiverIds) {
+        LocalTime lowerBound = getLowerBound();
+        LocalTime upperBound = getUpperBound(lowerBound);
+
+        return quickStartRepository.findEarliestQuickStartsForMembers(receiverIds, lowerBound, upperBound);
+    }
+
+    private QuickStart findEarliestQuickStartForReceiver(Member receiver, List<QuickStart> earliestQuickStartsForMembers) {
+        return earliestQuickStartsForMembers.stream()
+                .filter(quickStart -> receiver.getId().equals(quickStart.getMemberId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void sendEmail(Member receiver, QuickStart earliestQuickStart) {
+        String title = generateEmailTitle(receiver, earliestQuickStart);
+        SendEmailRequest request = SendEmailRequest.builder()
+                .title(title)
+                .content(generateEmailContent())
+                .receiver(receiver.getEmail())
+                .build();
+
+        try {
+            emailUtil.send(request);
+            log.info("[SendQuickStartEmailsScheduler] Successfully sent email to {}", receiver);
+        } catch (Exception e) {
+            log.error("[SendQuickStartEmailsScheduler] Failed to send email to {}", receiver, e);
         }
+    }
+
+    private String generateEmailTitle(Member receiver, QuickStart earliestQuickStart) {
+        return "%s 님, %s의 시간 조각을 모으러 갈 시간이에요 ⏰".formatted(receiver.getNickname(), earliestQuickStart.getName());
     }
 
     private String generateEmailContent() {
         Context context = new Context();
         return templateEngine.process("mail", context);
+    }
+
+    private LocalTime getLowerBound() {
+        LocalTime now = LocalTime.now();
+        return now.plusMinutes(1).withSecond(0).withNano(0);
+    }
+
+    private LocalTime getUpperBound(LocalTime lowerBound) {
+        return lowerBound.plusMinutes(TIME_INTERVAL_MINUTES - 1);
     }
 }

--- a/src/main/java/spring/backend/activity/application/SendQuickStartEmailsScheduler.java
+++ b/src/main/java/spring/backend/activity/application/SendQuickStartEmailsScheduler.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
 import spring.backend.activity.domain.entity.QuickStart;
 import spring.backend.activity.domain.repository.QuickStartRepository;
 import spring.backend.core.util.email.EmailUtil;
@@ -26,6 +28,8 @@ public class SendQuickStartEmailsScheduler {
     private final MemberRepository memberRepository;
 
     private final EmailUtil emailUtil;
+
+    private final TemplateEngine templateEngine;
 
     @Scheduled(cron = "0 0/15 * * * ?")
     public void sendQuickStartEmails() {
@@ -51,7 +55,7 @@ public class SendQuickStartEmailsScheduler {
         if (!receivers.isEmpty()) {
             SendEmailRequest request = SendEmailRequest.builder()
                     .title("Test Title")
-                    .content("Test Content")
+                    .content(generateEmailContent())
                     .receivers(receivers.toArray(new String[0]))
                     .build();
 
@@ -64,5 +68,10 @@ public class SendQuickStartEmailsScheduler {
         } else {
             log.warn("[SendQuickStartEmailsScheduler] No valid receivers found in the time range: {} - {}", lowerBound, upperBound);
         }
+    }
+
+    private String generateEmailContent() {
+        Context context = new Context();
+        return templateEngine.process("mail", context);
     }
 }

--- a/src/main/java/spring/backend/activity/domain/repository/QuickStartRepository.java
+++ b/src/main/java/spring/backend/activity/domain/repository/QuickStartRepository.java
@@ -2,12 +2,8 @@ package spring.backend.activity.domain.repository;
 
 import spring.backend.activity.domain.entity.QuickStart;
 
-import java.time.LocalTime;
-import java.util.List;
-
 public interface QuickStartRepository {
 
     QuickStart findById(Long id);
     QuickStart save(QuickStart quickStart);
-    List<QuickStart> findQuickStartsWithinTimeRange(LocalTime lowerBound, LocalTime upperBound);
 }

--- a/src/main/java/spring/backend/activity/domain/repository/QuickStartRepository.java
+++ b/src/main/java/spring/backend/activity/domain/repository/QuickStartRepository.java
@@ -2,8 +2,13 @@ package spring.backend.activity.domain.repository;
 
 import spring.backend.activity.domain.entity.QuickStart;
 
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
 public interface QuickStartRepository {
 
     QuickStart findById(Long id);
     QuickStart save(QuickStart quickStart);
+    List<QuickStart> findEarliestQuickStartsForMembers(List<UUID> memberIds, LocalTime lowerBound, LocalTime upperBound);
 }

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/adapter/QuickStartRepositoryImpl.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/adapter/QuickStartRepositoryImpl.java
@@ -10,12 +10,6 @@ import spring.backend.activity.infrastructure.mapper.QuickStartMapper;
 import spring.backend.activity.infrastructure.persistence.jpa.entity.QuickStartJpaEntity;
 import spring.backend.activity.infrastructure.persistence.jpa.repository.QuickStartJpaRepository;
 
-import java.time.LocalTime;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 @Repository
 @RequiredArgsConstructor
 @Log4j2
@@ -43,15 +37,5 @@ public class QuickStartRepositoryImpl implements QuickStartRepository {
             log.error("[QuickStartRepositoryImpl] Failed to save quickStart", e);
             throw QuickStartErrorCode.QUICK_START_SAVE_FAILED.toException();
         }
-    }
-
-    @Override
-    public List<QuickStart> findQuickStartsWithinTimeRange(LocalTime lowerBound, LocalTime upperBound) {
-        List<QuickStartJpaEntity> quickStartJpaEntities = quickStartJpaRepository.findQuickStartsWithinTimeRange(lowerBound, upperBound);
-        return Optional.ofNullable(quickStartJpaEntities)
-                .orElse(Collections.emptyList())
-                .stream()
-                .map(quickStartMapper::toDomainEntity)
-                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/adapter/QuickStartRepositoryImpl.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/adapter/QuickStartRepositoryImpl.java
@@ -10,6 +10,11 @@ import spring.backend.activity.infrastructure.mapper.QuickStartMapper;
 import spring.backend.activity.infrastructure.persistence.jpa.entity.QuickStartJpaEntity;
 import spring.backend.activity.infrastructure.persistence.jpa.repository.QuickStartJpaRepository;
 
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 @Repository
 @RequiredArgsConstructor
 @Log4j2
@@ -37,5 +42,16 @@ public class QuickStartRepositoryImpl implements QuickStartRepository {
             log.error("[QuickStartRepositoryImpl] Failed to save quickStart", e);
             throw QuickStartErrorCode.QUICK_START_SAVE_FAILED.toException();
         }
+    }
+
+    @Override
+    public List<QuickStart> findEarliestQuickStartsForMembers(List<UUID> memberIds, LocalTime lowerBound, LocalTime upperBound) {
+        List<QuickStartJpaEntity> quickStartJpaEntities = quickStartJpaRepository.findEarliestQuickStartsForMembers(memberIds, lowerBound, upperBound);
+        if (quickStartJpaEntities == null || quickStartJpaEntities.isEmpty()) {
+            return null;
+        }
+        return quickStartJpaEntities.stream()
+                .map(quickStartMapper::toDomainEntity)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/repository/QuickStartJpaRepository.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/repository/QuickStartJpaRepository.java
@@ -1,7 +1,21 @@
 package spring.backend.activity.infrastructure.persistence.jpa.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import spring.backend.activity.infrastructure.persistence.jpa.entity.QuickStartJpaEntity;
 
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+
 public interface QuickStartJpaRepository extends JpaRepository<QuickStartJpaEntity, Long> {
+
+    @Query("""
+        select q
+        from QuickStartJpaEntity q
+        where q.memberId in :memberIds
+        and q.startTime between :lowerBound and :upperBound
+        order by q.startTime asc
+    """)
+    List<QuickStartJpaEntity> findEarliestQuickStartsForMembers(List<UUID> memberIds, LocalTime lowerBound,LocalTime upperBound);
 }

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/repository/QuickStartJpaRepository.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/repository/QuickStartJpaRepository.java
@@ -1,24 +1,7 @@
 package spring.backend.activity.infrastructure.persistence.jpa.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import spring.backend.activity.infrastructure.persistence.jpa.entity.QuickStartJpaEntity;
 
-import java.time.LocalTime;
-import java.util.List;
-
 public interface QuickStartJpaRepository extends JpaRepository<QuickStartJpaEntity, Long> {
-
-    @Query("""
-        select q
-        from QuickStartJpaEntity q
-        where q.startTime = (
-            select MIN(q2.startTime)
-            from QuickStartJpaEntity q2
-            where q2.memberId = q.memberId
-            and q2.startTime between :lowerBound and :upperBound
-            group by q2.memberId
-        )
-    """)
-    List<QuickStartJpaEntity> findQuickStartsWithinTimeRange(LocalTime lowerBound, LocalTime upperBound);
 }

--- a/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/repository/QuickStartJpaRepository.java
+++ b/src/main/java/spring/backend/activity/infrastructure/persistence/jpa/repository/QuickStartJpaRepository.java
@@ -12,11 +12,11 @@ public interface QuickStartJpaRepository extends JpaRepository<QuickStartJpaEnti
     @Query("""
         select q
         from QuickStartJpaEntity q
-        where q.startTime between :lowerBound and :upperBound
-        and q.id in (
-            select min(q2.id)
+        where q.startTime = (
+            select MIN(q2.startTime)
             from QuickStartJpaEntity q2
             where q2.memberId = q.memberId
+            and q2.startTime between :lowerBound and :upperBound
             group by q2.memberId
         )
     """)

--- a/src/main/java/spring/backend/core/configuration/AsyncConfiguration.java
+++ b/src/main/java/spring/backend/core/configuration/AsyncConfiguration.java
@@ -1,0 +1,24 @@
+package spring.backend.core.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfiguration {
+
+    @Bean
+    public Executor mailExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(30);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("MailExecutor-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/spring/backend/core/util/email/EmailUtil.java
+++ b/src/main/java/spring/backend/core/util/email/EmailUtil.java
@@ -11,6 +11,7 @@ import org.springframework.mail.MailParseException;
 import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import spring.backend.core.util.email.dto.request.SendEmailRequest;
 import spring.backend.core.util.email.exception.MailErrorCode;
@@ -30,6 +31,7 @@ public class EmailUtil {
 
     private final JavaMailSender mailSender;
 
+    @Async("mailExecutor")
     public void send(SendEmailRequest sendEmailRequest) {
         validateEmailRequest(sendEmailRequest);
         try {

--- a/src/main/java/spring/backend/core/util/email/EmailUtil.java
+++ b/src/main/java/spring/backend/core/util/email/EmailUtil.java
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Component;
 import spring.backend.core.util.email.dto.request.SendEmailRequest;
 import spring.backend.core.util.email.exception.MailErrorCode;
 
-import java.util.Arrays;
 import java.util.regex.Pattern;
 
 @Component
@@ -38,14 +37,14 @@ public class EmailUtil {
             MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
             helper.setFrom(sender);
-            helper.setTo(sendEmailRequest.receivers());
+            helper.setTo(sendEmailRequest.receiver());
             helper.setSubject(sendEmailRequest.title());
             helper.setText(sendEmailRequest.content(), true);
 
             mailSender.send(message);
         } catch (MailParseException e) {
             log.error("[EmailUtil] Failed to parse email for recipient: {}, subject: {}. Error: {}",
-                    Arrays.toString(sendEmailRequest.receivers()), sendEmailRequest.title(), e.getMessage());
+                    sendEmailRequest.receiver(), sendEmailRequest.title(), e.getMessage());
             throw MailErrorCode.FAILED_TO_PARSE_MAIL.toException();
         } catch (MailAuthenticationException e) {
             log.error("[EmailUtil] Authentication failed for email sender: {}. Error: {}",
@@ -53,11 +52,11 @@ public class EmailUtil {
             throw MailErrorCode.AUTHENTICATION_FAILED.toException();
         } catch (MailSendException e) {
             log.error("[EmailUtil] Error occurred while sending email to recipient: {}, subject: {}. Error: {}",
-                    Arrays.toString(sendEmailRequest.receivers()), sendEmailRequest.title(), e.getMessage());
+                    sendEmailRequest.receiver(), sendEmailRequest.title(), e.getMessage());
             throw MailErrorCode.ERROR_OCCURRED_SENDING_MAIL.toException();
         } catch (MailException | MessagingException e) {
             log.error("[EmailUtil] General mail error for recipient: {}, subject: {}. Error: {}",
-                    Arrays.toString(sendEmailRequest.receivers()), sendEmailRequest.title(), e.getMessage());
+                    sendEmailRequest.receiver(), sendEmailRequest.title(), e.getMessage());
             throw MailErrorCode.GENERAL_MAIL_ERROR.toException();
         }
     }
@@ -69,8 +68,8 @@ public class EmailUtil {
     }
 
     private void validateEmailAddress(SendEmailRequest request) {
-        if (request.receivers() == null || Arrays.stream(request.receivers()).anyMatch(email -> !EMAIL_PATTERN.matcher(email).matches())) {
-            log.error("[EmailUtil] Invalid email address format: {}", Arrays.toString(request.receivers()));
+        if (request.receiver() == null || !EMAIL_PATTERN.matcher(request.receiver()).matches()) {
+            log.error("[EmailUtil] Invalid email address format: {}", request.receiver());
             throw MailErrorCode.INVALID_MAIL_ADDRESS.toException();
         }
     }

--- a/src/main/java/spring/backend/core/util/email/dto/request/SendEmailRequest.java
+++ b/src/main/java/spring/backend/core/util/email/dto/request/SendEmailRequest.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record SendEmailRequest(
-        String[] receivers,
+        String receiver,
         String title,
         String content
 ) {

--- a/src/main/java/spring/backend/member/domain/repository/MemberRepository.java
+++ b/src/main/java/spring/backend/member/domain/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package spring.backend.member.domain.repository;
 import spring.backend.member.domain.entity.Member;
 import spring.backend.member.domain.value.Role;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -13,4 +14,5 @@ public interface MemberRepository {
     Member findByEmail(String email);
     List<Member> findAllByEmail(String email);
     boolean existsByNicknameAndRole(String nickname, Role role);
+    List<Member> findMembersForQuickStartsInTimeRange(LocalTime lowerBound, LocalTime upperBound);
 }

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/adapter/MemberRepositoryImpl.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/adapter/MemberRepositoryImpl.java
@@ -11,6 +11,7 @@ import spring.backend.member.infrastructure.mapper.MemberMapper;
 import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
 import spring.backend.member.infrastructure.persistence.jpa.repository.MemberJpaRepository;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -63,5 +64,14 @@ public class MemberRepositoryImpl implements MemberRepository {
     @Override
     public boolean existsByNicknameAndRole(String nickname, Role role) {
         return memberJpaRepository.existsByNicknameAndRole(nickname, role);
+    }
+
+    @Override
+    public List<Member> findMembersForQuickStartsInTimeRange(LocalTime lowerBound, LocalTime upperBound) {
+        List<MemberJpaEntity> memberJpaEntities = memberJpaRepository.findMembersForQuickStartsInTimeRange(lowerBound, upperBound);
+        if (memberJpaEntities == null || memberJpaEntities.isEmpty()) {
+            return null;
+        }
+        return memberJpaEntities.stream().map(memberMapper::toDomainEntity).collect(Collectors.toList());
     }
 }

--- a/src/main/java/spring/backend/member/infrastructure/persistence/jpa/repository/MemberJpaRepository.java
+++ b/src/main/java/spring/backend/member/infrastructure/persistence/jpa/repository/MemberJpaRepository.java
@@ -1,9 +1,11 @@
 package spring.backend.member.infrastructure.persistence.jpa.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import spring.backend.member.domain.value.Role;
 import spring.backend.member.infrastructure.persistence.jpa.entity.MemberJpaEntity;
 
+import java.time.LocalTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -14,4 +16,13 @@ public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, UUID
     List<MemberJpaEntity> findAllByEmail(String email);
 
     boolean existsByNicknameAndRole(String nickname, Role role);
+
+    @Query("""
+        select distinct m
+        from MemberJpaEntity m
+        join QuickStartJpaEntity q on q.memberId = m.id
+        where q.startTime between :lowerBound and :upperBound
+        and m.emailNotification = true
+    """)
+    List<MemberJpaEntity> findMembersForQuickStartsInTimeRange(LocalTime lowerBound, LocalTime upperBound);
 }

--- a/src/main/resources/templates/mail.html
+++ b/src/main/resources/templates/mail.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8">
+    <title>조각조각 메일</title>
+  </head>
+  <body>
+    <table align="center" width="100%" cellspacing="0" cellpadding="0" border="0">
+      <tr>
+        <td align="center" style="padding: 0;">
+          <a href="https://cnergy.kro.kr/">
+            <img
+                    src="https://kr.object.ncloudstorage.com/cnergy-bucket/mail/mail.png"
+                    alt="조각조각 이미지"
+                    style="width: 100%; max-width: 600px; height: auto; border: none;"
+            />
+          </a>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 이번 작업은 빠른 시작 메일 전송 템플릿을 적용하는 작업인데.. 생각보다 추가, 수정되는 부분이 많아서 이슈로 새로 팔까 하다가 금일 제출이라 분리해서 올리면 빠듯할 거 같아 PR 작업 단위를 좀 크게 올리게 되었습니다.. 죄송합니다ㅜㅜ

### 주요 작업 내용

#### Feat
#### 메일 템플릿 적용
- 메일 템플릿을 원래 HTML, CSS를 이용하려다 메일 회사(구글, 네이버 등등)마다 기준이 다르고 똑같은 HTML이라도 보여지는게 다르게 보여지는 문제가 발생합니다.
- 문제를 해결하기 위해, 사진을 본문에 넣고 사진을 클릭하면 조각조각 메인 페이지로 넘어오게 구현하였습니다. (기획과 논의 완료)

#### Thymeleaf + SimpleMessage에서 MimeMessage로 변경
- 메일에 HTML을 넣어 템플릿을 적용하려면 Thymeleaf를 통한 템플릿 엔진을 사용하고, MimeMessage를 사용해서 HTML 조건을 추가해주어야 해서 변경하게 되었습니다.

#### 이메일 수신자를 벌크에서 단건으로 변경 및 비동기 처리
- 메일을 한 명씩 보내면 시간이 오래 걸려서 벌크로 보내기로 저번 작업에서 노티드렸습니다.
- 하지만 벌크로 보내게 되면, A사용자에게 B, C등 같이 보내는 이메일 주소가 노출되는 문제를 확인하였습니다.
- 이 문제를 해결하기 위해 단건으로 처리 후, AsyncConfiguration에서 쓰레드 풀을 설정하여 비동기로 메일을 전송하게 변경하였습니다.

#### 제목 커스텀
- 본문은 사진으로 보내는 만큼, 제목은 커스텀해서 전송합니다. (기획과 논의 완료)

---
#### Fix / Refactor

#### 기능을 메서드 단위로 분리
- 메서드의 기능을 명확히 하기 위해 기능 별로 분리하였습니다.

#### 빠른 시작을 조회에서 멤버 email을 가져오는 방식이 아닌 멤버와 빠른 시작을 조인해서 멤버를 조회
- 기존에는 빠른 시작을 조회하고, 스트림을 통해 빠른 시작의 memberId를 가지고 `memberRepository`에서 가져와서 email을 가져왔습니다. 이렇게 될 경우, 사용자가 많아질 수록 쿼리는 무수히 증가하여 성능에 문제를 일으킬 수 있습니다.
- Member와 QuickStart를 Join해서 시간대 사이에 빠른 시작이 있으면 멤버를 Distinct로 가져오게 하였습니다. 이로써 Member만 읽어오는 단일 쿼리로 성능상 문제를 해결했습니다.

#### 빠른 시작을 멤버 id 리스트를 통해 하나의 쿼리로 전부 가져온다
- 빠른 시작을 멤버 id 리스트로 In 조건을 추가하여 하나의 쿼리를 통해 빠른시작의 데이터를 가져올 수 있게 했습니다.
----
#### 웹 메일 응답 (Gmail, Naver)
![KakaoTalk_Photo_2024-11-28-02-16-29 002](https://github.com/user-attachments/assets/2700c321-c3ca-46d2-8983-ffa7d21ca65b)
![KakaoTalk_Photo_2024-11-28-02-16-29 001](https://github.com/user-attachments/assets/2aff35df-a702-4e93-83da-d33e7156d850)


#### 모바일 메일 응답 (Gmail, Naver)
![KakaoTalk_Photo_2024-11-28-02-16-54 002](https://github.com/user-attachments/assets/8aeb3154-0914-4ce0-8d87-a379ef00c7e0)
![KakaoTalk_Photo_2024-11-28-02-16-54 001](https://github.com/user-attachments/assets/74aa98a5-ee15-4347-9383-98cbf81b7282)


---

## ✏️ 관련 이슈
- Resolves : #151 
---

## 🎸 기타 사항 or 추가 코멘트
아자아자 파이팅!