### PR TITLE
Fix: (#157) 활동 키워드에서 키워드 이미지는 투명도 30으로 변경한다

### DIFF
--- a/src/main/java/spring/backend/activity/application/ReadActivitiesByMemberAndKeywordInMonthService.java
+++ b/src/main/java/spring/backend/activity/application/ReadActivitiesByMemberAndKeywordInMonthService.java
@@ -29,7 +29,7 @@ public class ReadActivitiesByMemberAndKeywordInMonthService {
         LocalDateTime endDayOfMonth = TimeUtil.toEndDayOfMonth(yearMonth);
         List<ActivityWithTitleAndSavedTimeResponse> activities = activityDao.findActivitiesByMemberAndKeywordInMonth(member.getId(), firstDayOfMonth, endDayOfMonth, keywordCategory);
         TotalSavedTimeAndActivityCountByKeywordInMonth totalSavedTimeAndActivityCountByKeywordInMonth = activityDao.findTotalSavedTimeAndActivityCountByKeywordInMonth(member.getId(), firstDayOfMonth, endDayOfMonth, keywordCategory);
-        Keyword keyword = Keyword.create(keywordCategory, imageConverter.convertToImageUrl(keywordCategory));
+        Keyword keyword = Keyword.create(keywordCategory, imageConverter.convertToTransparent30ImageUrl(keywordCategory));
         return new ActivitiesByMemberAndKeywordInMonthResponse(
                 totalSavedTimeAndActivityCountByKeywordInMonth.totalSavedTimeByKeywordInMonth(),
                 totalSavedTimeAndActivityCountByKeywordInMonth.totalActivityCountByKeywordInMonth(),

--- a/src/main/java/spring/backend/core/configuration/property/ImageProperty.java
+++ b/src/main/java/spring/backend/core/configuration/property/ImageProperty.java
@@ -17,4 +17,11 @@ public class ImageProperty {
     private String entertainmentImageUrl;
     private String relaxationImageUrl;
     private String socialImageUrl;
+
+    private String transparent30SelfDevelopmentImageUrl;
+    private String transparent30HealthImageUrl;
+    private String transparent30CultureArtImageUrl;
+    private String transparent30EntertainmentImageUrl;
+    private String transparent30RelaxationImageUrl;
+    private String transparent30SocialImageUrl;
 }

--- a/src/main/java/spring/backend/core/converter/ImageConverter.java
+++ b/src/main/java/spring/backend/core/converter/ImageConverter.java
@@ -15,6 +15,7 @@ public class ImageConverter {
 
     private final ImageProperty imageProperty;
     private final Map<Category, String> categoryImageMap = new HashMap<>();
+    private final Map<Category, String> categoryTransparent30ImageMap = new HashMap<>();
 
     @PostConstruct
     private void initializeImageMap() {
@@ -26,10 +27,27 @@ public class ImageConverter {
         categoryImageMap.put(Category.SOCIAL, imageProperty.getSocialImageUrl());
     }
 
+    @PostConstruct
+    private void initializeTransparent30ImageMap() {
+        categoryTransparent30ImageMap.put(Category.SELF_DEVELOPMENT, imageProperty.getTransparent30SelfDevelopmentImageUrl());
+        categoryTransparent30ImageMap.put(Category.HEALTH, imageProperty.getTransparent30HealthImageUrl());
+        categoryTransparent30ImageMap.put(Category.CULTURE_ART, imageProperty.getTransparent30CultureArtImageUrl());
+        categoryTransparent30ImageMap.put(Category.ENTERTAINMENT, imageProperty.getTransparent30EntertainmentImageUrl());
+        categoryTransparent30ImageMap.put(Category.RELAXATION, imageProperty.getTransparent30RelaxationImageUrl());
+        categoryTransparent30ImageMap.put(Category.SOCIAL, imageProperty.getTransparent30SocialImageUrl());
+    }
+
     public String convertToImageUrl(Category category) {
         if (category == null) {
             return null;
         }
         return categoryImageMap.get(category);
+    }
+
+    public String convertToTransparent30ImageUrl(Category category) {
+        if (category == null) {
+            return null;
+        }
+        return categoryTransparent30ImageMap.get(category);
     }
 }

--- a/src/test/java/spring/backend/core/converter/ImageConverterTest.java
+++ b/src/test/java/spring/backend/core/converter/ImageConverterTest.java
@@ -31,4 +31,17 @@ class ImageConverterTest {
 
         assertNull(imageConverter.convertToImageUrl(null));
     }
+
+    @DisplayName("주어진 카테고리에 맞는 투명도 30% 이미지 URL을 반환한다")
+    @Test
+    void mapCategoryTransparent30ImageUrl() {
+        assertEquals(imageProperty.getTransparent30SelfDevelopmentImageUrl(), imageConverter.convertToTransparent30ImageUrl(Category.SELF_DEVELOPMENT));
+        assertEquals(imageProperty.getTransparent30HealthImageUrl(), imageConverter.convertToTransparent30ImageUrl(Category.HEALTH));
+        assertEquals(imageProperty.getTransparent30CultureArtImageUrl(), imageConverter.convertToTransparent30ImageUrl(Category.CULTURE_ART));
+        assertEquals(imageProperty.getTransparent30EntertainmentImageUrl(), imageConverter.convertToTransparent30ImageUrl(Category.ENTERTAINMENT));
+        assertEquals(imageProperty.getTransparent30RelaxationImageUrl(), imageConverter.convertToTransparent30ImageUrl(Category.RELAXATION));
+        assertEquals(imageProperty.getTransparent30SocialImageUrl(), imageConverter.convertToTransparent30ImageUrl(Category.SOCIAL));
+
+        assertNull(imageConverter.convertToTransparent30ImageUrl(null));
+    }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- 프론트 요청 사항으로, 활동 키워드에서 키워드 이미지는 투명도 30인 이미지를 노출해야 해서 대응 작업입니다.
- 객체 스토리지에 파일 넣었고, 테스트코드와 swagger에서 각 카테고리 테스트 진행하였습니다.

---

## ✏️ 관련 이슈
- Resolves : #157 

---

## 🎸 기타 사항 or 추가 코멘트
- application.yml 업데이트 필요합니다.