### PR TITLE
 Fix: (#160) 조각 별 상세 정보가 아닌 활동 키워드에서 키워드 이미지는 투명도 30으로 변경한다

### DIFF
--- a/src/main/java/spring/backend/activity/application/ReadActivitiesByMemberAndKeywordInMonthService.java
+++ b/src/main/java/spring/backend/activity/application/ReadActivitiesByMemberAndKeywordInMonthService.java
@@ -29,7 +29,7 @@ public class ReadActivitiesByMemberAndKeywordInMonthService {
         LocalDateTime endDayOfMonth = TimeUtil.toEndDayOfMonth(yearMonth);
         List<ActivityWithTitleAndSavedTimeResponse> activities = activityDao.findActivitiesByMemberAndKeywordInMonth(member.getId(), firstDayOfMonth, endDayOfMonth, keywordCategory);
         TotalSavedTimeAndActivityCountByKeywordInMonth totalSavedTimeAndActivityCountByKeywordInMonth = activityDao.findTotalSavedTimeAndActivityCountByKeywordInMonth(member.getId(), firstDayOfMonth, endDayOfMonth, keywordCategory);
-        Keyword keyword = Keyword.create(keywordCategory, imageConverter.convertToTransparent30ImageUrl(keywordCategory));
+        Keyword keyword = Keyword.create(keywordCategory, imageConverter.convertToImageUrl(keywordCategory));
         return new ActivitiesByMemberAndKeywordInMonthResponse(
                 totalSavedTimeAndActivityCountByKeywordInMonth.totalSavedTimeByKeywordInMonth(),
                 totalSavedTimeAndActivityCountByKeywordInMonth.totalActivityCountByKeywordInMonth(),

--- a/src/main/java/spring/backend/activity/application/ReadMonthlyActivityOverviewService.java
+++ b/src/main/java/spring/backend/activity/application/ReadMonthlyActivityOverviewService.java
@@ -4,11 +4,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import spring.backend.activity.domain.value.Keyword.Category;
 import spring.backend.activity.dto.request.MonthlyActivityOverviewRequest;
 import spring.backend.activity.dto.response.MonthlyActivityCountByKeywordResponse;
 import spring.backend.activity.dto.response.MonthlyActivityOverviewResponse;
 import spring.backend.activity.dto.response.MonthlySavedTimeAndActivityCountResponse;
+import spring.backend.activity.infrastructure.persistence.jpa.value.KeywordJpaValue;
 import spring.backend.activity.query.dao.ActivityDao;
+import spring.backend.core.converter.ImageConverter;
 import spring.backend.core.util.TimeUtil;
 import spring.backend.member.domain.entity.Member;
 
@@ -24,12 +27,22 @@ public class ReadMonthlyActivityOverviewService {
 
     private final ActivityDao activityDao;
 
+    private final ImageConverter imageConverter;
+
     public MonthlyActivityOverviewResponse readMonthlyActivityOverview(Member member, MonthlyActivityOverviewRequest monthlyActivityOverviewRequest) {
         YearMonth yearMonth = YearMonth.of(monthlyActivityOverviewRequest.year(), monthlyActivityOverviewRequest.month());
         LocalDateTime startDayOfMonth = TimeUtil.toStartDayOfMonth(yearMonth);
         LocalDateTime endDayOfMonth = TimeUtil.toEndDayOfMonth(yearMonth);
         MonthlySavedTimeAndActivityCountResponse monthlySavedTimeAndActivityCountResponse = activityDao.findMonthlyTotalSavedTimeAndTotalCount(member.getId(), startDayOfMonth, endDayOfMonth);
         List<MonthlyActivityCountByKeywordResponse> activityByKeywordSummaryResponses = activityDao.findMonthlyActivitiesByKeywordSummary(member.getId(), startDayOfMonth, endDayOfMonth);
-        return new MonthlyActivityOverviewResponse(member.getUpdatedAt().getYear(), member.getUpdatedAt().getMonth(), monthlySavedTimeAndActivityCountResponse, activityByKeywordSummaryResponses);
+        List<MonthlyActivityCountByKeywordResponse> updatedActivityByKeywordSummaryResponses = activityByKeywordSummaryResponses.stream()
+                .map(response -> {
+                    Category category = response.keyword().getCategory();
+                    String imageUrl = imageConverter.convertToTransparent30ImageUrl(category);
+                    KeywordJpaValue updatedKeyword = KeywordJpaValue.create(category, imageUrl);
+                    return new MonthlyActivityCountByKeywordResponse(updatedKeyword, response.activityCount());
+                })
+                .toList();
+        return new MonthlyActivityOverviewResponse(member.getUpdatedAt().getYear(), member.getUpdatedAt().getMonth(), monthlySavedTimeAndActivityCountResponse, updatedActivityByKeywordSummaryResponses);
     }
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
![스크린샷 2024-11-28 오후 2 57 21](https://github.com/user-attachments/assets/d19ac29b-4119-431f-b228-3c33492e03ba)
원래 활동 키워드를 작업했어야했는데 API를 헷갈려서
![스크린샷 2024-11-28 오후 2 57 53](https://github.com/user-attachments/assets/c8105e15-86b0-4506-a14f-75f9e9c4b51a)
여기를 작업했습니다...

재변경 작업입니다
상세 정보 원복 및 Overview에서 투명도 30이미지 반환하게 하였습니다.
![스크린샷 2024-11-28 오후 2 53 40](https://github.com/user-attachments/assets/939eaf64-ea77-4a04-a278-ecd89836d5d2)
![스크린샷 2024-11-28 오후 2 53 30](https://github.com/user-attachments/assets/b2fe4826-f629-49c8-b7e9-c13f4a133ffd)

---

## ✏️ 관련 이슈
- Fixes : #159 
- Resolves : #160 

---

## 🎸 기타 사항 or 추가 코멘트