### PR TITLE
Fix: (#174) 온보딩 닉네임 설정 및 빠른시작 이름 설정 시 초성도 포함될 수 있다

### DIFF
--- a/src/main/java/spring/backend/auth/presentation/dto/request/OnboardingSignUpRequest.java
+++ b/src/main/java/spring/backend/auth/presentation/dto/request/OnboardingSignUpRequest.java
@@ -6,7 +6,7 @@ import spring.backend.member.domain.value.Gender;
 
 public record OnboardingSignUpRequest(
 
-        @Pattern(regexp = "^[a-zA-Z0-9가-힣]{1,6}$", message = "닉네임은 한글, 영문, 숫자 조합 6자 이내로 입력해주세요.")
+        @Pattern(regexp = "^[a-zA-Z0-9가-힣ㄱ-ㅎ]{1,6}$", message = "닉네임은 한글, 영문, 숫자 조합 6자 이내로 입력해주세요.")
         @Schema(description = "닉네임", example = "조각조각")
         String nickname,
 

--- a/src/main/java/spring/backend/member/domain/service/ValidateNicknameService.java
+++ b/src/main/java/spring/backend/member/domain/service/ValidateNicknameService.java
@@ -22,7 +22,7 @@ public class ValidateNicknameService {
             log.error("[ValidateNicknameService] Nickname is smaller than 6 characters");
             return false;
         }
-        if (!nickname.matches("^[a-zA-Z0-9가-힣]+$")) {
+        if (!nickname.matches("^[a-zA-Z0-9가-힣ㄱ-ㅎ]{1,6}$")) {
             log.error("[ValidateNicknameService] Nickname is invalid");
             return false;
         }

--- a/src/main/java/spring/backend/quickstart/presentation/dto/request/QuickStartRequest.java
+++ b/src/main/java/spring/backend/quickstart/presentation/dto/request/QuickStartRequest.java
@@ -7,7 +7,7 @@ import spring.backend.activity.domain.value.Type;
 public record QuickStartRequest(
 
         @NotNull(message = "이름은 필수 입력 항목입니다.")
-        @Pattern(regexp = "^(?!\\s)([a-zA-Z0-9가-힣]+(\\s[a-zA-Z0-9가-힣]+)*)?$", message = "이름은 한글, 영문, 숫자 및 공백만 입력 가능하며, 공백으로 시작하거나 끝날 수 없고, 연속된 공백이 없어야 합니다.")
+        @Pattern(regexp = "^(?!\\s)([a-zA-Z0-9가-힣ㄱ-ㅎ]+(\\s[a-zA-Z0-9가-힣ㄱ-ㅎ]+)*)?$", message = "이름은 한글(초성 포함), 영문, 숫자 및 공백만 입력 가능하며, 공백으로 시작하거나 끝날 수 없고, 연속된 공백이 없어야 합니다.")
         @Size(max = 10, message = "최대 10자까지 입력 가능합니다.")
         @Schema(description = "빠른 시작 이름", example = "등교")
         String name,

--- a/src/test/java/spring/backend/member/domain/service/ValidateNicknameServiceTest.java
+++ b/src/test/java/spring/backend/member/domain/service/ValidateNicknameServiceTest.java
@@ -3,6 +3,8 @@ package spring.backend.member.domain.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -10,6 +12,7 @@ import spring.backend.member.domain.repository.MemberRepository;
 import spring.backend.member.domain.value.Role;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,16 +50,6 @@ class ValidateNicknameServiceTest {
     }
 
     @Test
-    @DisplayName("닉네임 형식이 유효하지 않을 때 예외가 발생한다.")
-    void throwExceptionWhenNicknameFormatIsInvalid() {
-        // Given
-        String nickname = "조각ㅈㄱ";
-
-        // When & Then
-        assertFalse(validateNicknameService.validateNickname(nickname));
-    }
-
-    @Test
     @DisplayName("이미 등록된 닉네임일 경우 예외가 발생한다.")
     void throwExceptionWhenNicknameIsAlreadyRegistered() {
         // Given
@@ -68,5 +61,13 @@ class ValidateNicknameServiceTest {
 
         // Mock 객체 정상 동작 확인
         verify(memberRepository).existsByNicknameAndRole(nickname, Role.MEMBER);
+    }
+
+    @ParameterizedTest
+    @DisplayName("올바른 형식의 이름일 경우 성공한다.")
+    @ValueSource(strings = {"ㅍ카칩", "ㄱ", "포ㅋ칩", "포카ㅊ", "조각조각ㅈㄱ", "q", "qwerty"})
+    void validateNicknameWithInitialConsonants(String nickname) {
+        // When & Then
+        assertTrue(validateNicknameService.validateNickname(nickname));
     }
 }

--- a/src/test/java/spring/backend/quickstart/dto/request/QuickStartRequestTest.java
+++ b/src/test/java/spring/backend/quickstart/dto/request/QuickStartRequestTest.java
@@ -42,7 +42,7 @@ class QuickStartRequestTest {
 
         @ParameterizedTest
         @DisplayName("올바른 형식의 이름일 경우 성공한다.")
-        @ValueSource(strings = {"등교", "이름테스트", "John Doe", "사용자1"})
+        @ValueSource(strings = {"등교", "이름테스트", "띄어쓰기 포함 10", "사용자1", "ㄱ", "ㄱ나다라ㅁ바사ㅇㅈㅋ"})
         void whenNameIsValid_thenValidationSucceeds(String name) {
             QuickStartRequest request = new QuickStartRequest(name, 12, 30, "오전", 300, Type.OFFLINE);
             Set<ConstraintViolation<QuickStartRequest>> violations = validator.validate(request);
@@ -58,7 +58,7 @@ class QuickStartRequestTest {
             Set<ConstraintViolation<QuickStartRequest>> violations = validator.validate(request);
 
             assertThat(violations).isNotEmpty();
-            assertThat(violations).anyMatch(violation -> violation.getMessage().contains("이름은 한글, 영문, 숫자 및 공백만 입력 가능하며"));
+            assertThat(violations).anyMatch(violation -> violation.getMessage().contains("이름은 한글(초성 포함), 영문, 숫자 및 공백만 입력 가능하며,"));
         }
 
         @Test


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
- QA 진행 중, 온보딩과 빠른 시작 생성 시 초성이 입력되지 않는 이슈 대응 작업 입니다.
- 해결한 QA : [빠른 시작 이름 띄어쓰기 불가](https://www.notion.so/1na0s/1511dbb858ca4653ba73735e8e9d8d7d?pvs=4), [빠른 시작 이름 초성 입력 불가능](https://www.notion.so/1na0s/10a01a56f7144eafaf714420c92295ef?pvs=4), [온보딩 닉네임 띄어쓰기 불가](https://www.notion.so/1na0s/aa8cf9ea1cf449ecb51f0daf0cc93965?pvs=4)
- 테스트코드로 검증 완료하였습니다.

---

## ✏️ 관련 이슈
- Resolves : #174 

---

## 🎸 기타 사항 or 추가 코멘트
- 온보딩에서 띄어쓰기가 불가능한 것으로 알고 있는데, QA에서 띄어쓰기 관련 얘기가 있어서 이 부분은 기획 측과 얘기 다시 나눠보고 해당 PR 혹은 새로운 이슈 파서 진행할게요~!